### PR TITLE
fix: styling; make category element spec compliant

### DIFF
--- a/VAST 4.0 Samples/Ad_Verification-test.xml
+++ b/VAST 4.0 Samples/Ad_Verification-test.xml
@@ -1,66 +1,65 @@
 <VAST version="4.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.iab.com/VAST">
-    <Ad id="20001" sequence="1" conditionalAd="false">
-        <InLine>
-            <AdSystem version="4.0">iabtechlab</AdSystem>
-            <Error>http://example.com/error</Error>
-            <Extensions>
-                <Extension type="iab-Count">
-                    <total_available>
-                        <![CDATA[ 2 ]]>
-                    </total_available>
-                </Extension>
-            </Extensions>
-            <Impression id="Impression-ID">http://example.com/track/impression</Impression>
-            <Pricing model="cpm" currency="USD">
-                <![CDATA[ 25.00 ]]>
-            </Pricing>
-            <AdTitle>iabtechlab video ad</AdTitle>
-            <AdVerifications>
-                 <Verification>
-                       <JavaScriptResource>
-                         <![CDATA[https://verificationcompany1.com/verification_script1.js]]>
-                       </JavaScriptResource>
-                 </Verification>
-                 <Verification>
-                       <JavaScriptResource>
-                         <![CDATA[https://verificationcompany.com/untrusted.js]]>
-                       </JavaScriptResource>
-                 </Verification>
-            </AdVerifications>
-			<Advertiser>IAB Sample Company</Advertiser>
-			<Category />
-            <Creatives>
-                <Creative id="5480" sequence="1" adId="2447226">
-                  <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
-                    <Linear>
-                        <TrackingEvents>
-                           <Tracking event="start" offset="12:22:11">http://example.com/tracking/start</Tracking>
-                            <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
-                            <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
-                            <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
-                            <Tracking event="complete">http://example.com/tracking/complete</Tracking>
-                        </TrackingEvents>
-                        <Duration>00:00:16</Duration>
-                        <MediaFiles>
-                            <MediaFile id="5241" delivery="progressive" type="video/mp4" bitrate="2000" width="1280" height="720" minBitrate="1500" maxBitrate="2500" scalable="1" maintainAspectRatio="1" codec="0">
-                                <![CDATA[https://iabtechlab.com/wp-content/uploads/2016/07/VAST-4.0-Short-Intro.mp4]]>
-                            </MediaFile>
-                            <MediaFile id="5244" delivery="progressive" type="video/mp4" bitrate="1000" width="854" height="480" minBitrate="700" maxBitrate="1500" scalable="1" maintainAspectRatio="1" codec="0">
-                                <![CDATA[http://example.com/mediafile/mid_resolution.mp4]]>
-                            </MediaFile>
-                            <MediaFile id="5246" delivery="progressive" type="video/mp4" bitrate="600" width="640" height="360" minBitrate="500" maxBitrate="700" scalable="1" maintainAspectRatio="1" codec="0">
-                                <![CDATA[http://example.com/mediafile/low_resolution.mp4]]>
-                            </MediaFile>
-                        </MediaFiles>
-
-                        <VideoClicks>
-                            <ClickThrough id="blog">
-                                <![CDATA[https://iabtechlab.com]]>
-                            </ClickThrough>
-                        </VideoClicks>
-                    </Linear>
-                </Creative>
-            </Creatives>
-        </InLine>
-    </Ad>
+  <Ad id="20001" sequence="1" conditionalAd="false">
+    <InLine>
+      <AdSystem version="4.0">iabtechlab</AdSystem>
+      <Error>http://example.com/error</Error>
+      <Extensions>
+        <Extension type="iab-Count">
+          <total_available>
+            <![CDATA[ 2 ]]>
+          </total_available>
+        </Extension>
+      </Extensions>
+      <Impression id="Impression-ID">http://example.com/track/impression</Impression>
+      <Pricing model="cpm" currency="USD">
+        <![CDATA[ 25.00 ]]>
+      </Pricing>
+      <AdTitle>iabtechlab video ad</AdTitle>
+      <AdVerifications>
+        <Verification>
+          <JavaScriptResource>
+            <![CDATA[https://verificationcompany1.com/verification_script1.js]]>
+          </JavaScriptResource>
+        </Verification>
+        <Verification>
+          <JavaScriptResource>
+            <![CDATA[https://verificationcompany.com/untrusted.js]]>
+          </JavaScriptResource>
+        </Verification>
+      </AdVerifications>
+      <Advertiser>IAB Sample Company</Advertiser>
+      <Category/>
+      <Creatives>
+        <Creative id="5480" sequence="1" adId="2447226">
+          <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
+          <Linear>
+            <TrackingEvents>
+              <Tracking event="start" offset="12:22:11">http://example.com/tracking/start</Tracking>
+              <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
+              <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
+              <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
+              <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+            </TrackingEvents>
+            <Duration>00:00:16</Duration>
+            <MediaFiles>
+              <MediaFile id="5241" delivery="progressive" type="video/mp4" bitrate="2000" width="1280" height="720" minBitrate="1500" maxBitrate="2500" scalable="1" maintainAspectRatio="1" codec="0">
+                <![CDATA[https://iabtechlab.com/wp-content/uploads/2016/07/VAST-4.0-Short-Intro.mp4]]>
+              </MediaFile>
+              <MediaFile id="5244" delivery="progressive" type="video/mp4" bitrate="1000" width="854" height="480" minBitrate="700" maxBitrate="1500" scalable="1" maintainAspectRatio="1" codec="0">
+                <![CDATA[http://example.com/mediafile/mid_resolution.mp4]]>
+              </MediaFile>
+              <MediaFile id="5246" delivery="progressive" type="video/mp4" bitrate="600" width="640" height="360" minBitrate="500" maxBitrate="700" scalable="1" maintainAspectRatio="1" codec="0">
+                <![CDATA[http://example.com/mediafile/low_resolution.mp4]]>
+              </MediaFile>
+            </MediaFiles>
+            <VideoClicks>
+              <ClickThrough id="blog">
+                <![CDATA[https://iabtechlab.com]]>
+              </ClickThrough>
+            </VideoClicks>
+          </Linear>
+        </Creative>
+      </Creatives>
+    </InLine>
+  </Ad>
 </VAST>

--- a/VAST 4.0 Samples/Category-test.xml
+++ b/VAST 4.0 Samples/Category-test.xml
@@ -1,49 +1,47 @@
 <VAST version="4.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.iab.com/VAST">
-    <Ad id="20008" sequence="1" conditionalAd="false">
-        <InLine>
-            <AdSystem version="4.0">iabtechlab</AdSystem>
-            <Error>http://example.com/error</Error>
-            <Impression id="Impression-ID">http://example.com/track/impression</Impression>
-            <Pricing model="cpm" currency="USD">
-                <![CDATA[ 25.00 ]]>
-            </Pricing>
-            <AdTitle>iabtechlab video ad</AdTitle>
-             <Category authority="http://www.iabtechlab.com/categoryauthority">American Cuisine</Category>
-             <Category authority="http://www.iabtechlab.com/categoryauthority">Guitar</Category>
-             <Category authority="http://www.iabtechlab.com/categoryauthority">Vegan</Category>
-
-            <Creatives>
-                <Creative id="5480" sequence="1" adId="2447226">
-                  <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
-                    <Linear>
-                        <TrackingEvents>
-                           <Tracking event="start" offset="08:34:01">http://example.com/tracking/start</Tracking>
-                            <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
-                            <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
-                            <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
-                            <Tracking event="complete">http://example.com/tracking/complete</Tracking>
-                        </TrackingEvents>
-                        <Duration>00:00:16</Duration>
-                        <MediaFiles>
-                            <MediaFile id="5241" delivery="progressive" type="video/mp4" bitrate="2000" width="1280" height="720" minBitrate="1500" maxBitrate="2500" scalable="1" maintainAspectRatio="1" codec="0">
-                                <![CDATA[https://iabtechlab.com/wp-content/uploads/2016/07/VAST-4.0-Short-Intro.mp4]]>
-                            </MediaFile>
-                            <MediaFile id="5244" delivery="progressive" type="video/mp4" bitrate="1000" width="854" height="480" minBitrate="700" maxBitrate="1500" scalable="1" maintainAspectRatio="1" codec="0">
-                                <![CDATA[http://example.com/mediafile/mid_resolution.mp4]]>
-                            </MediaFile>
-                            <MediaFile id="5246" delivery="progressive" type="video/mp4" bitrate="600" width="640" height="360" minBitrate="500" maxBitrate="700" scalable="1" maintainAspectRatio="1" codec="0">
-                                <![CDATA[http://example.com/mediafile/low_resolution.mp4]]>
-                            </MediaFile>
-                        </MediaFiles>
-
-                        <VideoClicks>
-                            <ClickThrough id="blog">
-                                <![CDATA[https://iabtechlab.com]]>
-                            </ClickThrough>
-                        </VideoClicks>
-                    </Linear>
-                </Creative>
-            </Creatives>
-        </InLine>
-    </Ad>
+  <Ad id="20008" sequence="1" conditionalAd="false">
+    <InLine>
+      <AdSystem version="4.0">iabtechlab</AdSystem>
+      <Error>http://example.com/error</Error>
+      <Impression id="Impression-ID">http://example.com/track/impression</Impression>
+      <Pricing model="cpm" currency="USD">
+        <![CDATA[ 25.00 ]]>
+      </Pricing>
+      <AdTitle>iabtechlab video ad</AdTitle>
+      <Category authority="http://www.iabtechlab.com/categoryauthority">American Cuisine</Category>
+      <Category authority="http://www.iabtechlab.com/categoryauthority">Guitar</Category>
+      <Category authority="http://www.iabtechlab.com/categoryauthority">Vegan</Category>
+      <Creatives>
+        <Creative id="5480" sequence="1" adId="2447226">
+          <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
+          <Linear>
+            <TrackingEvents>
+              <Tracking event="start" offset="08:34:01">http://example.com/tracking/start</Tracking>
+              <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
+              <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
+              <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
+              <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+            </TrackingEvents>
+            <Duration>00:00:16</Duration>
+            <MediaFiles>
+              <MediaFile id="5241" delivery="progressive" type="video/mp4" bitrate="2000" width="1280" height="720" minBitrate="1500" maxBitrate="2500" scalable="1" maintainAspectRatio="1" codec="0">
+                <![CDATA[https://iabtechlab.com/wp-content/uploads/2016/07/VAST-4.0-Short-Intro.mp4]]>
+              </MediaFile>
+              <MediaFile id="5244" delivery="progressive" type="video/mp4" bitrate="1000" width="854" height="480" minBitrate="700" maxBitrate="1500" scalable="1" maintainAspectRatio="1" codec="0">
+                <![CDATA[http://example.com/mediafile/mid_resolution.mp4]]>
+              </MediaFile>
+              <MediaFile id="5246" delivery="progressive" type="video/mp4" bitrate="600" width="640" height="360" minBitrate="500" maxBitrate="700" scalable="1" maintainAspectRatio="1" codec="0">
+                <![CDATA[http://example.com/mediafile/low_resolution.mp4]]>
+              </MediaFile>
+            </MediaFiles>
+            <VideoClicks>
+              <ClickThrough id="blog">
+                <![CDATA[https://iabtechlab.com]]>
+              </ClickThrough>
+            </VideoClicks>
+          </Linear>
+        </Creative>
+      </Creatives>
+    </InLine>
+  </Ad>
 </VAST>

--- a/VAST 4.0 Samples/Conditional_Ad-test.xml
+++ b/VAST 4.0 Samples/Conditional_Ad-test.xml
@@ -1,56 +1,52 @@
 <VAST version="4.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.iab.com/VAST">
-    <Ad id="20002" sequence="1" conditionalAd="false">
-        <InLine>
-
-            <AdSystem version="4.0">iabtechlab</AdSystem>
-
-            <Error>http://example.com/error</Error>
-            <Extensions>
-                <Extension type="iab-Count">
-                    <total_available>
-                        <![CDATA[ 2 ]]>
-                    </total_available>
-                </Extension>
-            </Extensions>
-            <Impression id="Impression-ID">http://example.com/track/impression</Impression>
-            <Pricing model="cpm" currency="USD">
-                <![CDATA[ 25.00 ]]>
-            </Pricing>
-            <AdTitle>iabtechlab video ad</AdTitle>
-             <Category authority="http://www.iabtechlab.com/categoryauthority">AD CONTENT description category</Category>
-
-            <Creatives>
-                <Creative id="5480" sequence="1" adId="2447226" apiFramework="VAST">
-                  <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
-                    <Linear>
-                        <TrackingEvents>
-                           <Tracking event="start" offset="12:20:10">http://example.com/tracking/start</Tracking>
-                            <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
-                            <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
-                            <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
-                            <Tracking event="complete">http://example.com/tracking/complete</Tracking>
-                        </TrackingEvents>
-                        <Duration>00:00:16</Duration>
-                        <MediaFiles>
-                            <MediaFile id="5241" delivery="progressive" type="video/mp4" bitrate="2000" width="1280" height="720" minBitrate="1500" maxBitrate="2500" scalable="1" maintainAspectRatio="1" codec="0">
-                                <![CDATA[https://iabtechlab.com/wp-content/uploads/2016/07/VAST-4.0-Short-Intro.mp4]]>
-                            </MediaFile>
-                            <MediaFile id="5244" delivery="progressive" type="video/mp4" bitrate="1000" width="854" height="480" minBitrate="700" maxBitrate="1500" scalable="1" maintainAspectRatio="1" codec="0">
-                                <![CDATA[http://example.com/mediafile/mid_resolution.mp4]]>
-                            </MediaFile>
-                            <MediaFile id="5246" delivery="progressive" type="video/mp4" bitrate="600" width="640" height="360" minBitrate="500" maxBitrate="700" scalable="1" maintainAspectRatio="1" codec="0">
-                                <![CDATA[http://example.com/mediafile/low_resolution.mp4]]>
-                            </MediaFile>
-                        </MediaFiles>
-
-                        <VideoClicks>
-                            <ClickThrough id="blog">
-                                <![CDATA[https://iabtechlab.com]]>
-                            </ClickThrough>
-                        </VideoClicks>
-                    </Linear>
-                </Creative>
-            </Creatives>
-        </InLine>
-    </Ad>
+  <Ad id="20002" sequence="1" conditionalAd="false">
+    <InLine>
+      <AdSystem version="4.0">iabtechlab</AdSystem>
+      <Error>http://example.com/error</Error>
+      <Extensions>
+        <Extension type="iab-Count">
+          <total_available>
+            <![CDATA[ 2 ]]>
+          </total_available>
+        </Extension>
+      </Extensions>
+      <Impression id="Impression-ID">http://example.com/track/impression</Impression>
+      <Pricing model="cpm" currency="USD">
+        <![CDATA[ 25.00 ]]>
+      </Pricing>
+      <AdTitle>iabtechlab video ad</AdTitle>
+      <Category authority="http://www.iabtechlab.com/categoryauthority">AD CONTENT description category</Category>
+      <Creatives>
+        <Creative id="5480" sequence="1" adId="2447226" apiFramework="VAST">
+          <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
+          <Linear>
+            <TrackingEvents>
+              <Tracking event="start" offset="12:20:10">http://example.com/tracking/start</Tracking>
+              <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
+              <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
+              <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
+              <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+            </TrackingEvents>
+            <Duration>00:00:16</Duration>
+            <MediaFiles>
+              <MediaFile id="5241" delivery="progressive" type="video/mp4" bitrate="2000" width="1280" height="720" minBitrate="1500" maxBitrate="2500" scalable="1" maintainAspectRatio="1" codec="0">
+                <![CDATA[https://iabtechlab.com/wp-content/uploads/2016/07/VAST-4.0-Short-Intro.mp4]]>
+              </MediaFile>
+              <MediaFile id="5244" delivery="progressive" type="video/mp4" bitrate="1000" width="854" height="480" minBitrate="700" maxBitrate="1500" scalable="1" maintainAspectRatio="1" codec="0">
+                <![CDATA[http://example.com/mediafile/mid_resolution.mp4]]>
+              </MediaFile>
+              <MediaFile id="5246" delivery="progressive" type="video/mp4" bitrate="600" width="640" height="360" minBitrate="500" maxBitrate="700" scalable="1" maintainAspectRatio="1" codec="0">
+                <![CDATA[http://example.com/mediafile/low_resolution.mp4]]>
+              </MediaFile>
+            </MediaFiles>
+            <VideoClicks>
+              <ClickThrough id="blog">
+                <![CDATA[https://iabtechlab.com]]>
+              </ClickThrough>
+            </VideoClicks>
+          </Linear>
+        </Creative>
+      </Creatives>
+    </InLine>
+  </Ad>
 </VAST>

--- a/VAST 4.0 Samples/Event_Tracking-test.xml
+++ b/VAST 4.0 Samples/Event_Tracking-test.xml
@@ -1,56 +1,51 @@
 <VAST version="4.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.iab.com/VAST">
-    <Ad id="20001" sequence="1" conditionalAd="false">
-        <InLine>
-
-            <AdSystem version="4.0">iabtechlab</AdSystem>
-
-            <Error>http://example.com/error</Error>
-            <Extensions>
-                <Extension type="iab-Count">
-                    <total_available>
-                        <![CDATA[ 2 ]]>
-                    </total_available>
-                </Extension>
-            </Extensions>
-            <Impression id="Impression-ID">http://example.com/track/impression</Impression>
-            <Pricing model="cpm" currency="USD">
-                <![CDATA[ 25.00 ]]>
-            </Pricing>
-
-            <AdTitle>iabtechlab video ad</AdTitle>
-
-            <Creatives>
-                <Creative id="5480" sequence="1" adId="2447226">
-                  <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
-                    <Linear>
-                        <TrackingEvents>
-                           <Tracking event="start" offset="10:05:20">http://example.com/tracking/start</Tracking>
-                            <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
-                            <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
-                            <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
-                            <Tracking event="complete">http://example.com/tracking/complete</Tracking>
-                        </TrackingEvents>
-                        <Duration>00:00:16</Duration>
-                        <MediaFiles>
-                            <MediaFile id="5241" delivery="progressive" type="video/mp4" bitrate="2000" width="1280" height="720" minBitrate="1500" maxBitrate="2500" scalable="1" maintainAspectRatio="1" codec="0">
-                                <![CDATA[https://iabtechlab.com/wp-content/uploads/2016/07/VAST-4.0-Short-Intro.mp4]]>
-                            </MediaFile>
-                            <MediaFile id="5244" delivery="progressive" type="video/mp4" bitrate="1000" width="854" height="480" minBitrate="700" maxBitrate="1500" scalable="1" maintainAspectRatio="1" codec="0">
-                                <![CDATA[http://example.com/mediafile/mid_resolution.mp4]]>
-                            </MediaFile>
-                            <MediaFile id="5246" delivery="progressive" type="video/mp4" bitrate="600" width="640" height="360" minBitrate="500" maxBitrate="700" scalable="1" maintainAspectRatio="1" codec="0">
-                                <![CDATA[http://example.com/mediafile/low_resolution.mp4]]>
-                            </MediaFile>
-                        </MediaFiles>
-
-                        <VideoClicks>
-                            <ClickThrough id="blog">
-                                <![CDATA[https://iabtechlab.com]]>
-                            </ClickThrough>
-                        </VideoClicks>
-                    </Linear>
-                </Creative>
-            </Creatives>
-        </InLine>
-    </Ad>
+  <Ad id="20001" sequence="1" conditionalAd="false">
+    <InLine>
+      <AdSystem version="4.0">iabtechlab</AdSystem>
+      <Error>http://example.com/error</Error>
+      <Extensions>
+        <Extension type="iab-Count">
+          <total_available>
+            <![CDATA[ 2 ]]>
+          </total_available>
+        </Extension>
+      </Extensions>
+      <Impression id="Impression-ID">http://example.com/track/impression</Impression>
+      <Pricing model="cpm" currency="USD">
+        <![CDATA[ 25.00 ]]>
+      </Pricing>
+      <AdTitle>iabtechlab video ad</AdTitle>
+      <Creatives>
+        <Creative id="5480" sequence="1" adId="2447226">
+          <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
+          <Linear>
+            <TrackingEvents>
+              <Tracking event="start" offset="10:05:20">http://example.com/tracking/start</Tracking>
+              <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
+              <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
+              <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
+              <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+            </TrackingEvents>
+            <Duration>00:00:16</Duration>
+            <MediaFiles>
+              <MediaFile id="5241" delivery="progressive" type="video/mp4" bitrate="2000" width="1280" height="720" minBitrate="1500" maxBitrate="2500" scalable="1" maintainAspectRatio="1" codec="0">
+                <![CDATA[https://iabtechlab.com/wp-content/uploads/2016/07/VAST-4.0-Short-Intro.mp4]]>
+              </MediaFile>
+              <MediaFile id="5244" delivery="progressive" type="video/mp4" bitrate="1000" width="854" height="480" minBitrate="700" maxBitrate="1500" scalable="1" maintainAspectRatio="1" codec="0">
+                <![CDATA[http://example.com/mediafile/mid_resolution.mp4]]>
+              </MediaFile>
+              <MediaFile id="5246" delivery="progressive" type="video/mp4" bitrate="600" width="640" height="360" minBitrate="500" maxBitrate="700" scalable="1" maintainAspectRatio="1" codec="0">
+                <![CDATA[http://example.com/mediafile/low_resolution.mp4]]>
+              </MediaFile>
+            </MediaFiles>
+            <VideoClicks>
+              <ClickThrough id="blog">
+                <![CDATA[https://iabtechlab.com]]>
+              </ClickThrough>
+            </VideoClicks>
+          </Linear>
+        </Creative>
+      </Creatives>
+    </InLine>
+  </Ad>
 </VAST>

--- a/VAST 4.0 Samples/Inline_Companion_Tag-test.xml
+++ b/VAST 4.0 Samples/Inline_Companion_Tag-test.xml
@@ -1,73 +1,69 @@
-<VAST version="4.0" xmlns="http://www.iab.com/VAST" >
-    <Ad id="20004" sequence="1" conditionalAd="false">
-        <InLine>
-            <AdSystem version="4.0">iabtechlab</AdSystem>
-
-            <Error>http://example.com/error</Error>
-            <Extensions>
-                <Extension type="iab-Count">
-                    <total_available>
-                        <![CDATA[ 2 ]]>
-                    </total_available>
-                </Extension>
-            </Extensions>
-            <Impression id="Impression-ID">http://example.com/track/impression</Impression>
-            <Pricing model="cpm" currency="USD">
-                <![CDATA[ 25.00 ]]>
-            </Pricing>
-
-            <AdTitle>
-                <![CDATA[VAST 4.0 Pilot - Scenario 5]]>
-            </AdTitle>
-            <Creatives>
-                <Creative id="5480" sequence="1" adId="2447226" >
-                     <CompanionAds>
-                        <Companion id="1232" width="100" height="150" assetWidth="250" assetHeight="200" expandedWidth="350" expandedHeight="250" adSlotID="3214" pxratio="1400">
-                            <StaticResource creativeType="image/png">
-                                <![CDATA[https://www.iab.com/wp-content/uploads/2014/09/iab-tech-lab-6-644x290.png]]>
-                                </StaticResource>
-                                <CompanionClickThrough>
-                                    <![CDATA[https://iabtechlab.com]]>
-                                </CompanionClickThrough>
-                        </Companion>
-                     </CompanionAds>
-                    <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
-                </Creative>
-                <Creative id="5480" sequence="1" adId="2447226">
-                    <Linear>
-                        <TrackingEvents>
-                           <Tracking event="start" offset="09:15:23">http://example.com/tracking/start</Tracking>
-                            <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
-                            <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
-                            <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
-                            <Tracking event="complete">http://example.com/tracking/complete</Tracking>
-                        </TrackingEvents>
-                        <Duration>00:00:16</Duration>
-                        <MediaFiles>
-                            <MediaFile id="5241" delivery="progressive" type="video/mp4" bitrate="2000" width="1280" height="720" minBitrate="1500" maxBitrate="2500" scalable="1" maintainAspectRatio="1" codec="0">
-                                <![CDATA[https://iabtechlab.com/wp-content/uploads/2016/07/VAST-4.0-Short-Intro.mp4]]>
-                            </MediaFile>
-                            <MediaFile id="5244" delivery="progressive" type="video/mp4" bitrate="1000" width="854" height="480" minBitrate="700" maxBitrate="1500" scalable="1" maintainAspectRatio="1" codec="0">
-                                <![CDATA[http://example.com/mediafile/mid_resolution.mp4]]>
-                            </MediaFile>
-                            <MediaFile id="5246" delivery="progressive" type="video/mp4" bitrate="600" width="640" height="360" minBitrate="500" maxBitrate="700" scalable="1" maintainAspectRatio="1" codec="0">
-                                <![CDATA[http://example.com/mediafile/low_resolution.mp4]]>
-                            </MediaFile>
-                        </MediaFiles>
-
-                        <VideoClicks>
-                            <ClickThrough id="blog">
-                                <![CDATA[https://iabtechlab.com]]>
-                            </ClickThrough>
-                        </VideoClicks>
-                    </Linear>
-                    <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
-                </Creative>
-
-            </Creatives>
-            <Description>
-                <![CDATA[This is sample companion ad tag with Linear ad tag. This tag while showing video ad on the player, will show a companion ad beside the player where it can be fitted. At most 3 companion ads can be placed. Modify accordingly to see your own content. ]]>
-            </Description>
-        </InLine>
-    </Ad>
+<VAST version="4.0" xmlns="http://www.iab.com/VAST">
+  <Ad id="20004" sequence="1" conditionalAd="false">
+    <InLine>
+      <AdSystem version="4.0">iabtechlab</AdSystem>
+      <Error>http://example.com/error</Error>
+      <Extensions>
+        <Extension type="iab-Count">
+          <total_available>
+            <![CDATA[ 2 ]]>
+          </total_available>
+        </Extension>
+      </Extensions>
+      <Impression id="Impression-ID">http://example.com/track/impression</Impression>
+      <Pricing model="cpm" currency="USD">
+        <![CDATA[ 25.00 ]]>
+      </Pricing>
+      <AdTitle>
+        <![CDATA[VAST 4.0 Pilot - Scenario 5]]>
+      </AdTitle>
+      <Creatives>
+        <Creative id="5480" sequence="1" adId="2447226">
+          <CompanionAds>
+            <Companion id="1232" width="100" height="150" assetWidth="250" assetHeight="200" expandedWidth="350" expandedHeight="250" adSlotID="3214" pxratio="1400">
+              <StaticResource creativeType="image/png">
+                <![CDATA[https://www.iab.com/wp-content/uploads/2014/09/iab-tech-lab-6-644x290.png]]>
+              </StaticResource>
+              <CompanionClickThrough>
+                <![CDATA[https://iabtechlab.com]]>
+              </CompanionClickThrough>
+            </Companion>
+          </CompanionAds>
+          <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
+        </Creative>
+        <Creative id="5480" sequence="1" adId="2447226">
+          <Linear>
+            <TrackingEvents>
+              <Tracking event="start" offset="09:15:23">http://example.com/tracking/start</Tracking>
+              <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
+              <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
+              <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
+              <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+            </TrackingEvents>
+            <Duration>00:00:16</Duration>
+            <MediaFiles>
+              <MediaFile id="5241" delivery="progressive" type="video/mp4" bitrate="2000" width="1280" height="720" minBitrate="1500" maxBitrate="2500" scalable="1" maintainAspectRatio="1" codec="0">
+                <![CDATA[https://iabtechlab.com/wp-content/uploads/2016/07/VAST-4.0-Short-Intro.mp4]]>
+              </MediaFile>
+              <MediaFile id="5244" delivery="progressive" type="video/mp4" bitrate="1000" width="854" height="480" minBitrate="700" maxBitrate="1500" scalable="1" maintainAspectRatio="1" codec="0">
+                <![CDATA[http://example.com/mediafile/mid_resolution.mp4]]>
+              </MediaFile>
+              <MediaFile id="5246" delivery="progressive" type="video/mp4" bitrate="600" width="640" height="360" minBitrate="500" maxBitrate="700" scalable="1" maintainAspectRatio="1" codec="0">
+                <![CDATA[http://example.com/mediafile/low_resolution.mp4]]>
+              </MediaFile>
+            </MediaFiles>
+            <VideoClicks>
+              <ClickThrough id="blog">
+                <![CDATA[https://iabtechlab.com]]>
+              </ClickThrough>
+            </VideoClicks>
+          </Linear>
+          <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
+        </Creative>
+      </Creatives>
+      <Description>
+        <![CDATA[This is sample companion ad tag with Linear ad tag. This tag while showing video ad on the player, will show a companion ad beside the player where it can be fitted. At most 3 companion ads can be placed. Modify accordingly to see your own content. ]]>
+      </Description>
+    </InLine>
+  </Ad>
 </VAST>

--- a/VAST 4.0 Samples/Inline_Linear_Tag-test.xml
+++ b/VAST 4.0 Samples/Inline_Linear_Tag-test.xml
@@ -1,54 +1,51 @@
-<VAST version="4.0" xmlns:xs="http://www.w3.org/2001/XMLSchema"  xmlns="http://www.iab.com/VAST">
-    <Ad id="20001" sequence="1" conditionalAd="false">
-        <InLine>
-            <AdSystem version="4.0">iabtechlab</AdSystem>
-            <Error>http://example.com/error</Error>
-            <Extensions>
-                <Extension type="iab-Count">
-                    <total_available>
-                        <![CDATA[ 2 ]]>
-                    </total_available>
-                </Extension>
-            </Extensions>
-            <Impression id="Impression-ID">http://example.com/track/impression</Impression>
-            <Pricing model="cpm" currency="USD">
-                <![CDATA[ 25.00 ]]>
-            </Pricing>
-
-            <AdTitle>iabtechlab video ad</AdTitle>
-
-            <Creatives>
-                <Creative id="5480" sequence="1" adId="2447226">
-                  <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
-                    <Linear>
-                        <TrackingEvents>
-                           <Tracking event="start" offset="09:15:23">http://example.com/tracking/start</Tracking>
-                            <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
-                            <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
-                            <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
-                            <Tracking event="complete">http://example.com/tracking/complete</Tracking>
-                        </TrackingEvents>
-                        <Duration>00:00:16</Duration>
-                        <MediaFiles>
-                            <MediaFile id="5241" delivery="progressive" type="video/mp4" bitrate="2000" width="1280" height="720" minBitrate="1500" maxBitrate="2500" scalable="1" maintainAspectRatio="1" codec="0">
-                                <![CDATA[https://iabtechlab.com/wp-content/uploads/2016/07/VAST-4.0-Short-Intro.mp4]]>
-                            </MediaFile>
-                            <MediaFile id="5244" delivery="progressive" type="video/mp4" bitrate="1000" width="854" height="480" minBitrate="700" maxBitrate="1500" scalable="1" maintainAspectRatio="1" codec="0">
-                                <![CDATA[http://example.com/mediafile/mid_resolution.mp4]]>
-                            </MediaFile>
-                            <MediaFile id="5246" delivery="progressive" type="video/mp4" bitrate="600" width="640" height="360" minBitrate="500" maxBitrate="700" scalable="1" maintainAspectRatio="1" codec="0">
-                                <![CDATA[http://example.com/mediafile/low_resolution.mp4]]>
-                            </MediaFile>
-                        </MediaFiles>
-
-                        <VideoClicks>
-                            <ClickThrough id="blog">
-                                <![CDATA[https://iabtechlab.com]]>
-                            </ClickThrough>
-                        </VideoClicks>
-                    </Linear>
-                </Creative>
-            </Creatives>
-        </InLine>
-    </Ad>
+<VAST version="4.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.iab.com/VAST">
+  <Ad id="20001" sequence="1" conditionalAd="false">
+    <InLine>
+      <AdSystem version="4.0">iabtechlab</AdSystem>
+      <Error>http://example.com/error</Error>
+      <Extensions>
+        <Extension type="iab-Count">
+          <total_available>
+            <![CDATA[ 2 ]]>
+          </total_available>
+        </Extension>
+      </Extensions>
+      <Impression id="Impression-ID">http://example.com/track/impression</Impression>
+      <Pricing model="cpm" currency="USD">
+        <![CDATA[ 25.00 ]]>
+      </Pricing>
+      <AdTitle>iabtechlab video ad</AdTitle>
+      <Creatives>
+        <Creative id="5480" sequence="1" adId="2447226">
+          <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
+          <Linear>
+            <TrackingEvents>
+              <Tracking event="start" offset="09:15:23">http://example.com/tracking/start</Tracking>
+              <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
+              <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
+              <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
+              <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+            </TrackingEvents>
+            <Duration>00:00:16</Duration>
+            <MediaFiles>
+              <MediaFile id="5241" delivery="progressive" type="video/mp4" bitrate="2000" width="1280" height="720" minBitrate="1500" maxBitrate="2500" scalable="1" maintainAspectRatio="1" codec="0">
+                <![CDATA[https://iabtechlab.com/wp-content/uploads/2016/07/VAST-4.0-Short-Intro.mp4]]>
+              </MediaFile>
+              <MediaFile id="5244" delivery="progressive" type="video/mp4" bitrate="1000" width="854" height="480" minBitrate="700" maxBitrate="1500" scalable="1" maintainAspectRatio="1" codec="0">
+                <![CDATA[http://example.com/mediafile/mid_resolution.mp4]]>
+              </MediaFile>
+              <MediaFile id="5246" delivery="progressive" type="video/mp4" bitrate="600" width="640" height="360" minBitrate="500" maxBitrate="700" scalable="1" maintainAspectRatio="1" codec="0">
+                <![CDATA[http://example.com/mediafile/low_resolution.mp4]]>
+              </MediaFile>
+            </MediaFiles>
+            <VideoClicks>
+              <ClickThrough id="blog">
+                <![CDATA[https://iabtechlab.com]]>
+              </ClickThrough>
+            </VideoClicks>
+          </Linear>
+        </Creative>
+      </Creatives>
+    </InLine>
+  </Ad>
 </VAST>

--- a/VAST 4.0 Samples/Inline_Non-Linear_Tag-test.xml
+++ b/VAST 4.0 Samples/Inline_Non-Linear_Tag-test.xml
@@ -1,55 +1,47 @@
 <VAST version="4.0" xmlns="http://www.iab.com/VAST">
-    <Ad id="20005" sequence="1" conditionalAd="false">
-        <InLine>
-            <AdSystem version="4.0">iabtechlab</AdSystem>
-            <Error>
-            <![CDATA[
-            http://example.com/error
-            ]]>
-            </Error>
-            <Extensions>
-                <Extension type="iab-Count">
-                    <total_available>
-                        <![CDATA[ 2 ]]>
-                    </total_available>
-                </Extension>
-            </Extensions>
-            <Impression id="Impression-ID">
-            <![CDATA[
-            http://example.com/track/impression
-            ]]>
-            </Impression>
-            <Pricing model="cpm" currency="USD">
-                <![CDATA[ 25.00 ]]>
-            </Pricing>
-
-            <AdTitle>
-                <![CDATA[VAST 4.0 Pilot - Scenario 5]]>
-            </AdTitle>
-
-            <Creatives>
-                <Creative id="5480" sequence="1" adId="2447226">
-                    <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
-        	    <NonLinearAds>
-      		         <NonLinear>
-                            <StaticResource creativeType="image/png">
-                                <![CDATA[
-                                http://mms.businesswire.com/media/20150623005446/en/473787/21/iab_tech_lab.jpg
-                            ]]>
-                            </StaticResource>
-                            <NonLinearClickThrough>
-                                <![CDATA[http://iabtechlab.com]]>
-                            </NonLinearClickThrough>
-                            <NonLinearClickTracking>
-                                <![CDATA[http://example.com/trackingurl/clickTracking]]>
-                            </NonLinearClickTracking>
-                        </NonLinear>
-                    </NonLinearAds>
-                </Creative>
-            </Creatives>
-            <Description>
-                <![CDATA[VAST 4.0 sample tag for Non Linear ad (i.e Overlay ad). Change the StaticResources to have a tag with your own content. Change NonLinear tag's parameters accordingly to view desired results.]]>
-            </Description>
-        </InLine>
-    </Ad>
+  <Ad id="20005" sequence="1" conditionalAd="false">
+    <InLine>
+      <AdSystem version="4.0">iabtechlab</AdSystem>
+      <Error>
+        <![CDATA[http://example.com/error]]>
+      </Error>
+      <Extensions>
+        <Extension type="iab-Count">
+          <total_available>
+            <![CDATA[ 2 ]]>
+          </total_available>
+        </Extension>
+      </Extensions>
+      <Impression id="Impression-ID">
+        <![CDATA[http://example.com/track/impression]]>
+      </Impression>
+      <Pricing model="cpm" currency="USD">
+        <![CDATA[ 25.00 ]]>
+      </Pricing>
+      <AdTitle>
+        <![CDATA[VAST 4.0 Pilot - Scenario 5]]>
+      </AdTitle>
+      <Creatives>
+        <Creative id="5480" sequence="1" adId="2447226">
+          <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
+          <NonLinearAds>
+            <NonLinear>
+              <StaticResource creativeType="image/png">
+                <![CDATA[http://mms.businesswire.com/media/20150623005446/en/473787/21/iab_tech_lab.jpg]]>
+              </StaticResource>
+              <NonLinearClickThrough>
+                <![CDATA[http://iabtechlab.com]]>
+              </NonLinearClickThrough>
+              <NonLinearClickTracking>
+                <![CDATA[http://example.com/trackingurl/clickTracking]]>
+              </NonLinearClickTracking>
+            </NonLinear>
+          </NonLinearAds>
+        </Creative>
+      </Creatives>
+      <Description>
+        <![CDATA[VAST 4.0 sample tag for Non Linear ad (i.e Overlay ad). Change the StaticResources to have a tag with your own content. Change NonLinear tag's parameters accordingly to view desired results.]]>
+      </Description>
+    </InLine>
+  </Ad>
 </VAST>

--- a/VAST 4.0 Samples/Inline_Simple.xml
+++ b/VAST 4.0 Samples/Inline_Simple.xml
@@ -1,53 +1,47 @@
-<VAST version="4.0" xmlns:xs="http://www.w3.org/2001/XMLSchema"  xmlns="http://www.iab.com/VAST">
-    <Ad id="20001" sequence="1" conditionalAd="false">
-        <InLine>
-            <AdSystem version="4.0">iabtechlab</AdSystem>
-
-            <Error>http://example.com/error</Error>
-
-            <Impression id="Impression-ID">http://example.com/track/impression</Impression>
-
-            <Pricing model="cpm" currency="USD">
-                <![CDATA[ 25.00 ]]>
-            </Pricing>
-
-            <AdTitle>Inline Simple Ad</AdTitle>
-			<AdVerifications></AdVerifications>
-			<Advertiser>IAB Sample Company</Advertiser>
-			<Category />
-            <Creatives>
-                <Creative id="5480" sequence="1" adId="2447226">
-                  <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
-                    <Linear>
-                        <TrackingEvents>
-                           <Tracking event="start" offset="09:15:23">http://example.com/tracking/start</Tracking>
-                            <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
-                            <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
-                            <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
-                            <Tracking event="complete">http://example.com/tracking/complete</Tracking>
-                        </TrackingEvents>
-                        <Duration>00:00:16</Duration>
-                        <MediaFiles>
-                            <MediaFile id="5241" delivery="progressive" type="video/mp4" bitrate="2000" width="1280" height="720" minBitrate="1500" maxBitrate="2500" scalable="1" maintainAspectRatio="1" codec="0">
-                                <![CDATA[https://iabtechlab.com/wp-content/uploads/2016/07/VAST-4.0-Short-Intro.mp4]]>
-                            </MediaFile>
-                            <MediaFile id="5244" delivery="progressive" type="video/mp4" bitrate="1000" width="854" height="480" minBitrate="700" maxBitrate="1500" scalable="1" maintainAspectRatio="1" codec="0">
-                                <![CDATA[http://example.com/mediafile/mid_resolution.mp4]]>
-                            </MediaFile>
-                            <MediaFile id="5246" delivery="progressive" type="video/mp4" bitrate="600" width="640" height="360" minBitrate="500" maxBitrate="700" scalable="1" maintainAspectRatio="1" codec="0">
-                                <![CDATA[http://example.com/mediafile/low_resolution.mp4]]>
-                            </MediaFile>
-                        </MediaFiles>
-
-                        <VideoClicks>
-                            <ClickThrough id="blog">
-                                <![CDATA[https://iabtechlab.com]]>
-                            </ClickThrough>
-                        </VideoClicks>
-                    </Linear>
-                </Creative>
-            </Creatives>
-
-        </InLine>
-    </Ad>
+<VAST version="4.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.iab.com/VAST">
+  <Ad id="20001" sequence="1" conditionalAd="false">
+    <InLine>
+      <AdSystem version="4.0">iabtechlab</AdSystem>
+      <Error>http://example.com/error</Error>
+      <Impression id="Impression-ID">http://example.com/track/impression</Impression>
+      <Pricing model="cpm" currency="USD">
+        <![CDATA[ 25.00 ]]>
+      </Pricing>
+      <AdTitle>Inline Simple Ad</AdTitle>
+      <AdVerifications></AdVerifications>
+      <Advertiser>IAB Sample Company</Advertiser>
+      <Category authority="http://www.iabtechlab.com/categoryauthority">AD CONTENT description category</Category>
+      <Creatives>
+        <Creative id="5480" sequence="1" adId="2447226">
+          <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
+          <Linear>
+            <TrackingEvents>
+              <Tracking event="start" offset="09:15:23">http://example.com/tracking/start</Tracking>
+              <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
+              <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
+              <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
+              <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+            </TrackingEvents>
+            <Duration>00:00:16</Duration>
+            <MediaFiles>
+              <MediaFile id="5241" delivery="progressive" type="video/mp4" bitrate="2000" width="1280" height="720" minBitrate="1500" maxBitrate="2500" scalable="1" maintainAspectRatio="1" codec="0">
+                <![CDATA[https://iabtechlab.com/wp-content/uploads/2016/07/VAST-4.0-Short-Intro.mp4]]>
+              </MediaFile>
+              <MediaFile id="5244" delivery="progressive" type="video/mp4" bitrate="1000" width="854" height="480" minBitrate="700" maxBitrate="1500" scalable="1" maintainAspectRatio="1" codec="0">
+                <![CDATA[http://example.com/mediafile/mid_resolution.mp4]]>
+              </MediaFile>
+              <MediaFile id="5246" delivery="progressive" type="video/mp4" bitrate="600" width="640" height="360" minBitrate="500" maxBitrate="700" scalable="1" maintainAspectRatio="1" codec="0">
+                <![CDATA[http://example.com/mediafile/low_resolution.mp4]]>
+              </MediaFile>
+            </MediaFiles>
+            <VideoClicks>
+              <ClickThrough id="blog">
+                <![CDATA[https://iabtechlab.com]]>
+              </ClickThrough>
+            </VideoClicks>
+          </Linear>
+        </Creative>
+      </Creatives>
+    </InLine>
+  </Ad>
 </VAST>

--- a/VAST 4.0 Samples/No_Wrapper_Tag-test.xml
+++ b/VAST 4.0 Samples/No_Wrapper_Tag-test.xml
@@ -1,57 +1,51 @@
 <VAST version="4.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.iab.com/VAST">
-    <Ad id="20001" sequence="1" conditionalAd="false">
-        <InLine>
-
-            <AdSystem version="4.0">iabtechlab</AdSystem>
-            <Error>http://example.com/error</Error>
-            <Extensions>
-                <Extension type="iab-Count">
-                    <total_available>
-                        <![CDATA[ 2 ]]>
-                    </total_available>
-                </Extension>
-            </Extensions>
-
-            <Impression id="Impression-ID">http://example.com/track/impression</Impression>
-            <Pricing model="cpm" currency="USD">
-                <![CDATA[ 25.00 ]]>
-            </Pricing>
-
-
-            <AdTitle>iabtechlab video ad</AdTitle>
-
-            <Creatives>
-                <Creative id="5480" sequence="1" adId="2447226">
-                  <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
-                    <Linear>
-                        <TrackingEvents>
-                           <Tracking event="start" offset="09:34:50">http://example.com/tracking/start</Tracking>
-                            <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
-                            <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
-                            <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
-                            <Tracking event="complete">http://example.com/tracking/complete</Tracking>
-                        </TrackingEvents>
-                        <Duration>00:00:16</Duration>
-                        <MediaFiles>
-                            <MediaFile id="5241" delivery="progressive" type="video/mp4" bitrate="2000" width="1280" height="720" minBitrate="1500" maxBitrate="2500" scalable="1" maintainAspectRatio="1" codec="0">
-                                <![CDATA[https://iabtechlab.com/wp-content/uploads/2016/07/VAST-4.0-Short-Intro.mp4]]>
-                            </MediaFile>
-                            <MediaFile id="5244" delivery="progressive" type="video/mp4" bitrate="1000" width="854" height="480" minBitrate="700" maxBitrate="1500" scalable="1" maintainAspectRatio="1" codec="0">
-                                <![CDATA[http://example.com/mediafile/mid_resolution.mp4]]>
-                            </MediaFile>
-                            <MediaFile id="5246" delivery="progressive" type="video/mp4" bitrate="600" width="640" height="360" minBitrate="500" maxBitrate="700" scalable="1" maintainAspectRatio="1" codec="0">
-                                <![CDATA[http://example.com/mediafile/low_resolution.mp4]]>
-                            </MediaFile>
-                        </MediaFiles>
-
-                        <VideoClicks>
-                            <ClickThrough id="blog">
-                                <![CDATA[https://iabtechlab.com]]>
-                            </ClickThrough>
-                        </VideoClicks>
-                    </Linear>
-                </Creative>
-            </Creatives>
-        </InLine>
-    </Ad>
+  <Ad id="20001" sequence="1" conditionalAd="false">
+    <InLine>
+      <AdSystem version="4.0">iabtechlab</AdSystem>
+      <Error>http://example.com/error</Error>
+      <Extensions>
+        <Extension type="iab-Count">
+          <total_available>
+            <![CDATA[ 2 ]]>
+          </total_available>
+        </Extension>
+      </Extensions>
+      <Impression id="Impression-ID">http://example.com/track/impression</Impression>
+      <Pricing model="cpm" currency="USD">
+        <![CDATA[ 25.00 ]]>
+      </Pricing>
+      <AdTitle>iabtechlab video ad</AdTitle>
+      <Creatives>
+        <Creative id="5480" sequence="1" adId="2447226">
+          <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
+          <Linear>
+            <TrackingEvents>
+              <Tracking event="start" offset="09:34:50">http://example.com/tracking/start</Tracking>
+              <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
+              <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
+              <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
+              <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+            </TrackingEvents>
+            <Duration>00:00:16</Duration>
+            <MediaFiles>
+              <MediaFile id="5241" delivery="progressive" type="video/mp4" bitrate="2000" width="1280" height="720" minBitrate="1500" maxBitrate="2500" scalable="1" maintainAspectRatio="1" codec="0">
+                <![CDATA[https://iabtechlab.com/wp-content/uploads/2016/07/VAST-4.0-Short-Intro.mp4]]>
+              </MediaFile>
+              <MediaFile id="5244" delivery="progressive" type="video/mp4" bitrate="1000" width="854" height="480" minBitrate="700" maxBitrate="1500" scalable="1" maintainAspectRatio="1" codec="0">
+                <![CDATA[http://example.com/mediafile/mid_resolution.mp4]]>
+              </MediaFile>
+              <MediaFile id="5246" delivery="progressive" type="video/mp4" bitrate="600" width="640" height="360" minBitrate="500" maxBitrate="700" scalable="1" maintainAspectRatio="1" codec="0">
+                <![CDATA[http://example.com/mediafile/low_resolution.mp4]]>
+              </MediaFile>
+            </MediaFiles>
+            <VideoClicks>
+              <ClickThrough id="blog">
+                <![CDATA[https://iabtechlab.com]]>
+              </ClickThrough>
+            </VideoClicks>
+          </Linear>
+        </Creative>
+      </Creatives>
+    </InLine>
+  </Ad>
 </VAST>

--- a/VAST 4.0 Samples/Ready_to_serve_Media_Files_check-test.xml
+++ b/VAST 4.0 Samples/Ready_to_serve_Media_Files_check-test.xml
@@ -1,56 +1,51 @@
 <VAST version="4.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.iab.com/VAST">
-    <Ad id="20007" sequence="1" conditionalAd="false">
-        <InLine>
-
-            <AdSystem version="4.0">iabtechlab</AdSystem>
-            <Error>http://example.com/error</Error>
-            <Extensions>
-                <Extension type="iab-Count">
-                    <total_available>
-                        <![CDATA[ 2 ]]>
-                    </total_available>
-                </Extension>
-            </Extensions>
-            <Impression id="Impression-ID">http://example.com/track/impression</Impression>
-
-            <Pricing model="cpm" currency="USD">
-                <![CDATA[ 25.00 ]]>
-            </Pricing>
-
-            <AdTitle>iabtechlab video ad</AdTitle>
-
-            <Creatives>
-                <Creative id="5480" sequence="1" adId="2447226">
-                  <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
-                    <Linear>
-                        <TrackingEvents>
-                           <Tracking event="start" offset="01:28:23">http://example.com/tracking/start</Tracking>
-                            <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
-                            <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
-                            <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
-                            <Tracking event="complete">http://example.com/tracking/complete</Tracking>
-                        </TrackingEvents>
-                        <Duration>00:00:16</Duration>
-                        <MediaFiles>
-                            <MediaFile id="5241" delivery="progressive" type="video/mp4" bitrate="2000" width="1280" height="720" minBitrate="1500" maxBitrate="2500" scalable="1" maintainAspectRatio="1" codec="0">
-                                <![CDATA[https://iabtechlab.com/wp-content/uploads/2016/07/VAST-4.0-Short-Intro.mp4]]>
-                            </MediaFile>
-                            <MediaFile id="5244" delivery="progressive" type="video/mp4" bitrate="1000" width="854" height="480" minBitrate="700" maxBitrate="1500" scalable="1" maintainAspectRatio="1" codec="0">
-                                <![CDATA[http://example.com/mediafile/mid_resolution.mp4]]>
-                            </MediaFile>
-                            <MediaFile id="5246" delivery="progressive" type="video/mp4" bitrate="600" width="640" height="360" minBitrate="500" maxBitrate="700" scalable="1" maintainAspectRatio="1" codec="0">
-                                <![CDATA[http://example.com/mediafile/low_resolution.mp4]]>
-                            </MediaFile>
-                        </MediaFiles>
-
-                        <VideoClicks>
-                            <ClickThrough id="blog">
-                                <![CDATA[https://iabtechlab.com]]>
-                            </ClickThrough>
-                        </VideoClicks>
-                    </Linear>
-                </Creative>
-            </Creatives>
-        </InLine>
-    </Ad>
+  <Ad id="20007" sequence="1" conditionalAd="false">
+    <InLine>
+      <AdSystem version="4.0">iabtechlab</AdSystem>
+      <Error>http://example.com/error</Error>
+      <Extensions>
+        <Extension type="iab-Count">
+          <total_available>
+            <![CDATA[ 2 ]]>
+          </total_available>
+        </Extension>
+      </Extensions>
+      <Impression id="Impression-ID">http://example.com/track/impression</Impression>
+      <Pricing model="cpm" currency="USD">
+        <![CDATA[ 25.00 ]]>
+      </Pricing>
+      <AdTitle>iabtechlab video ad</AdTitle>
+      <Creatives>
+        <Creative id="5480" sequence="1" adId="2447226">
+          <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
+          <Linear>
+            <TrackingEvents>
+              <Tracking event="start" offset="01:28:23">http://example.com/tracking/start</Tracking>
+              <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
+              <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
+              <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
+              <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+            </TrackingEvents>
+            <Duration>00:00:16</Duration>
+            <MediaFiles>
+              <MediaFile id="5241" delivery="progressive" type="video/mp4" bitrate="2000" width="1280" height="720" minBitrate="1500" maxBitrate="2500" scalable="1" maintainAspectRatio="1" codec="0">
+                <![CDATA[https://iabtechlab.com/wp-content/uploads/2016/07/VAST-4.0-Short-Intro.mp4]]>
+              </MediaFile>
+              <MediaFile id="5244" delivery="progressive" type="video/mp4" bitrate="1000" width="854" height="480" minBitrate="700" maxBitrate="1500" scalable="1" maintainAspectRatio="1" codec="0">
+                <![CDATA[http://example.com/mediafile/mid_resolution.mp4]]>
+              </MediaFile>
+              <MediaFile id="5246" delivery="progressive" type="video/mp4" bitrate="600" width="640" height="360" minBitrate="500" maxBitrate="700" scalable="1" maintainAspectRatio="1" codec="0">
+                <![CDATA[http://example.com/mediafile/low_resolution.mp4]]>
+              </MediaFile>
+            </MediaFiles>
+            <VideoClicks>
+              <ClickThrough id="blog">
+                <![CDATA[https://iabtechlab.com]]>
+              </ClickThrough>
+            </VideoClicks>
+          </Linear>
+        </Creative>
+      </Creatives>
+    </InLine>
+  </Ad>
 </VAST>

--- a/VAST 4.0 Samples/SSAI_stitching _VPAID_separation-test.xml
+++ b/VAST 4.0 Samples/SSAI_stitching _VPAID_separation-test.xml
@@ -1,52 +1,51 @@
 <VAST version="4.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.iab.com/VAST">
-    <Ad id="20001" sequence="1" conditionalAd="false">
-        <InLine>
-            <AdSystem version="4.0">iabtechlab</AdSystem>
-            <Error>http://example.com/error</Error>
-            <Extensions>
-                <Extension type="iab-Count">
-                    <total_available>
-                        <![CDATA[ 2 ]]>
-                    </total_available>
-                </Extension>
-            </Extensions>
-            <Impression id="Impression-ID">http://example.com/track/impression</Impression>
-            <Pricing model="cpm" currency="USD">
-                <![CDATA[ 25.00 ]]>
-            </Pricing>
-
-            <AdTitle>iabtechlab video ad</AdTitle>
-
-            <Creatives>
-                <Creative id="5480" sequence="1" adId="2447226">
-                  <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
-                    <Linear>
-                        <TrackingEvents>
-                           <Tracking event="start" offset="10:32:23">http://example.com/tracking/start</Tracking>
-                            <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
-                            <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
-                            <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
-                            <Tracking event="complete">http://example.com/tracking/complete</Tracking>
-                        </TrackingEvents>
-                        <Duration>00:00:16</Duration>
-                        <MediaFiles>
-                            <MediaFile id="5241" delivery="progressive" type="video/mp4" bitrate="2500" width="1280" height="720" minBitrate="1800" maxBitrate="2500" scalable="1" maintainAspectRatio="1" codec="0" >
-                                <![CDATA[http://cdn.iabcdn.com/website/engineering/vast_4_0_pilot/vast_4.0_pilot-iab-hd.mp4]]>
-                            </MediaFile>
-                            <Mezzanine><![CDATA[http://pilot.iabtechlab.com/beacon?type=complete&imprid=s5-ea2f7f298e28c0c98374491aec3dfeb1&ts=4235]]></Mezzanine>
-                            <InteractiveCreativeFile>
-                                <![CDATA[http://pilot.iabtechlab.com/beacon?type=complete&imprid=s5-ea2f7f298e28c0c98374491aec3dfeb1&ts=4235]]>
-                            </InteractiveCreativeFile>
-                        </MediaFiles>
-
-                        <VideoClicks>
-                            <ClickThrough id="blog">
-                                <![CDATA[https://iabtechlab.com]]>
-                            </ClickThrough>
-                        </VideoClicks>
-                    </Linear>
-                </Creative>
-            </Creatives>
-        </InLine>
-    </Ad>
+  <Ad id="20001" sequence="1" conditionalAd="false">
+    <InLine>
+      <AdSystem version="4.0">iabtechlab</AdSystem>
+      <Error>http://example.com/error</Error>
+      <Extensions>
+        <Extension type="iab-Count">
+          <total_available>
+            <![CDATA[ 2 ]]>
+          </total_available>
+        </Extension>
+      </Extensions>
+      <Impression id="Impression-ID">http://example.com/track/impression</Impression>
+      <Pricing model="cpm" currency="USD">
+        <![CDATA[ 25.00 ]]>
+      </Pricing>
+      <AdTitle>iabtechlab video ad</AdTitle>
+      <Creatives>
+        <Creative id="5480" sequence="1" adId="2447226">
+          <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
+          <Linear>
+            <TrackingEvents>
+              <Tracking event="start" offset="10:32:23">http://example.com/tracking/start</Tracking>
+              <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
+              <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
+              <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
+              <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+            </TrackingEvents>
+            <Duration>00:00:16</Duration>
+            <MediaFiles>
+              <MediaFile id="5241" delivery="progressive" type="video/mp4" bitrate="2500" width="1280" height="720" minBitrate="1800" maxBitrate="2500" scalable="1" maintainAspectRatio="1" codec="0">
+                <![CDATA[http://cdn.iabcdn.com/website/engineering/vast_4_0_pilot/vast_4.0_pilot-iab-hd.mp4]]>
+              </MediaFile>
+              <Mezzanine>
+                <![CDATA[http://pilot.iabtechlab.com/beacon?type=complete&imprid=s5-ea2f7f298e28c0c98374491aec3dfeb1&ts=4235]]>
+              </Mezzanine>
+              <InteractiveCreativeFile>
+                <![CDATA[http://pilot.iabtechlab.com/beacon?type=complete&imprid=s5-ea2f7f298e28c0c98374491aec3dfeb1&ts=4235]]>
+              </InteractiveCreativeFile>
+            </MediaFiles>
+            <VideoClicks>
+              <ClickThrough id="blog">
+                <![CDATA[https://iabtechlab.com]]>
+              </ClickThrough>
+            </VideoClicks>
+          </Linear>
+        </Creative>
+      </Creatives>
+    </InLine>
+  </Ad>
 </VAST>

--- a/VAST 4.0 Samples/SSAI_stitching_mezzanine_file_support-test.xml
+++ b/VAST 4.0 Samples/SSAI_stitching_mezzanine_file_support-test.xml
@@ -1,50 +1,47 @@
 <VAST version="4.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.iab.com/VAST">
-    <Ad id="20001" sequence="1" conditionalAd="false">
-        <InLine>
-
-            <AdSystem version="4.0">iabtechlab</AdSystem>
-            <Error>http://example.com/error</Error>
-
-            <Impression id="Impression-ID">http://example.com/track/impression</Impression>
-            <Pricing model="cpm" currency="USD">
-                <![CDATA[ 25.00 ]]>
-            </Pricing>
-
-            <AdTitle>iabtechlab video ad</AdTitle>
-
-            <Creatives>
-                <Creative id="5480" sequence="1" adId="2447226" apiFramework="VPAID">
-                  <UniversalAdId idRegistry="Ad-ID" idValue="8465">1234</UniversalAdId>
-                    <Linear>
-                        <TrackingEvents>
-                           <Tracking event="start" offset="01:34:00">http://example.com/tracking/start</Tracking>
-                            <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
-                            <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
-                            <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
-                            <Tracking event="complete">http://example.com/tracking/complete</Tracking>
-                        </TrackingEvents>
-                        <Duration>00:00:16</Duration>
-                        <MediaFiles>
-                            <MediaFile id="5241" delivery="progressive" type="video/mp4" bitrate="2000" width="1280" height="720" minBitrate="1500" maxBitrate="2500" scalable="1" maintainAspectRatio="1" codec="0">
-                                <![CDATA[https://iabtechlab.com/wp-content/uploads/2016/07/VAST-4.0-Short-Intro.mp4]]>
-                            </MediaFile>
-                            <MediaFile id="5244" delivery="progressive" type="video/mp4" bitrate="1000" width="854" height="480" minBitrate="700" maxBitrate="1500" scalable="1" maintainAspectRatio="1" codec="0">
-                                <![CDATA[http://example.com/mediafile/mid_resolution.mp4]]>
-                            </MediaFile>
-                            <MediaFile id="5246" delivery="progressive" type="video/mp4" bitrate="600" width="640" height="360" minBitrate="500" maxBitrate="700" scalable="1" maintainAspectRatio="1" codec="0">
-                                <![CDATA[http://example.com/mediafile/low_resolution.mp4]]>
-                            </MediaFile>
-                            <Mezzanine><![CDATA[http://pilot.iabtechlab.com/beacon?type=complete&imprid=s5-ea2f7f298e28c0c98374491aec3dfeb1&ts=4235]]></Mezzanine>
-                        </MediaFiles>
-
-                        <VideoClicks>
-                            <ClickThrough id="blog">
-                                <![CDATA[https://iabtechlab.com]]>
-                            </ClickThrough>
-                        </VideoClicks>
-                    </Linear>
-                </Creative>
-            </Creatives>
-        </InLine>
-    </Ad>
-  </VAST>
+  <Ad id="20001" sequence="1" conditionalAd="false">
+    <InLine>
+      <AdSystem version="4.0">iabtechlab</AdSystem>
+      <Error>http://example.com/error</Error>
+      <Impression id="Impression-ID">http://example.com/track/impression</Impression>
+      <Pricing model="cpm" currency="USD">
+        <![CDATA[ 25.00 ]]>
+      </Pricing>
+      <AdTitle>iabtechlab video ad</AdTitle>
+      <Creatives>
+        <Creative id="5480" sequence="1" adId="2447226" apiFramework="VPAID">
+          <UniversalAdId idRegistry="Ad-ID" idValue="8465">1234</UniversalAdId>
+          <Linear>
+            <TrackingEvents>
+              <Tracking event="start" offset="01:34:00">http://example.com/tracking/start</Tracking>
+              <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
+              <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
+              <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
+              <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+            </TrackingEvents>
+            <Duration>00:00:16</Duration>
+            <MediaFiles>
+              <MediaFile id="5241" delivery="progressive" type="video/mp4" bitrate="2000" width="1280" height="720" minBitrate="1500" maxBitrate="2500" scalable="1" maintainAspectRatio="1" codec="0">
+                <![CDATA[https://iabtechlab.com/wp-content/uploads/2016/07/VAST-4.0-Short-Intro.mp4]]>
+              </MediaFile>
+              <MediaFile id="5244" delivery="progressive" type="video/mp4" bitrate="1000" width="854" height="480" minBitrate="700" maxBitrate="1500" scalable="1" maintainAspectRatio="1" codec="0">
+                <![CDATA[http://example.com/mediafile/mid_resolution.mp4]]>
+              </MediaFile>
+              <MediaFile id="5246" delivery="progressive" type="video/mp4" bitrate="600" width="640" height="360" minBitrate="500" maxBitrate="700" scalable="1" maintainAspectRatio="1" codec="0">
+                <![CDATA[http://example.com/mediafile/low_resolution.mp4]]>
+              </MediaFile>
+              <Mezzanine>
+                <![CDATA[http://pilot.iabtechlab.com/beacon?type=complete&imprid=s5-ea2f7f298e28c0c98374491aec3dfeb1&ts=4235]]>
+              </Mezzanine>
+            </MediaFiles>
+            <VideoClicks>
+              <ClickThrough id="blog">
+                <![CDATA[https://iabtechlab.com]]>
+              </ClickThrough>
+            </VideoClicks>
+          </Linear>
+        </Creative>
+      </Creatives>
+    </InLine>
+  </Ad>
+</VAST>

--- a/VAST 4.0 Samples/Universal_Ad_ID-test.xml
+++ b/VAST 4.0 Samples/Universal_Ad_ID-test.xml
@@ -1,54 +1,52 @@
 <VAST version="4.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.iab.com/VAST">
-    <Ad id="20008" sequence="1" conditionalAd="false">
-        <InLine>
-            <AdSystem version="4.0">iabtechlab</AdSystem>
-            <Error>http://example.com/error</Error>
-            <Extensions>
-                <Extension type="iab-Count">
-                    <total_available>
-                        <![CDATA[ 2 ]]>
-                    </total_available>
-                </Extension>
-            </Extensions>
-            <Impression id="Impression-ID">http://example.com/track/impression</Impression>
-            <Pricing model="cpm" currency="USD">
-                <![CDATA[ 25.00 ]]>
-            </Pricing>
-            <AdTitle>iabtechlab video ad</AdTitle>
-             <Category authority="http://www.iabtechlab.com/categoryauthority">AD CONTENT description category</Category>
-
-            <Creatives>
-                <Creative id="5480" sequence="1" adId="2447226">
-                  <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
-                    <Linear>
-                        <TrackingEvents>
-                           <Tracking event="start" offset="08:34:01">http://example.com/tracking/start</Tracking>
-                            <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
-                            <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
-                            <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
-                            <Tracking event="complete">http://example.com/tracking/complete</Tracking>
-                        </TrackingEvents>
-                        <Duration>00:00:16</Duration>
-                        <MediaFiles>
-                            <MediaFile id="5241" delivery="progressive" type="video/mp4" bitrate="2000" width="1280" height="720" minBitrate="1500" maxBitrate="2500" scalable="1" maintainAspectRatio="1" codec="0">
-                                <![CDATA[https://iabtechlab.com/wp-content/uploads/2016/07/VAST-4.0-Short-Intro.mp4]]>
-                            </MediaFile>
-                            <MediaFile id="5244" delivery="progressive" type="video/mp4" bitrate="1000" width="854" height="480" minBitrate="700" maxBitrate="1500" scalable="1" maintainAspectRatio="1" codec="0">
-                                <![CDATA[http://example.com/mediafile/mid_resolution.mp4]]>
-                            </MediaFile>
-                            <MediaFile id="5246" delivery="progressive" type="video/mp4" bitrate="600" width="640" height="360" minBitrate="500" maxBitrate="700" scalable="1" maintainAspectRatio="1" codec="0">
-                                <![CDATA[http://example.com/mediafile/low_resolution.mp4]]>
-                            </MediaFile>
-                        </MediaFiles>
-
-                        <VideoClicks>
-                            <ClickThrough id="blog">
-                                <![CDATA[https://iabtechlab.com]]>
-                            </ClickThrough>
-                        </VideoClicks>
-                    </Linear>
-                </Creative>
-            </Creatives>
-        </InLine>
-    </Ad>
+  <Ad id="20008" sequence="1" conditionalAd="false">
+    <InLine>
+      <AdSystem version="4.0">iabtechlab</AdSystem>
+      <Error>http://example.com/error</Error>
+      <Extensions>
+        <Extension type="iab-Count">
+          <total_available>
+            <![CDATA[ 2 ]]>
+          </total_available>
+        </Extension>
+      </Extensions>
+      <Impression id="Impression-ID">http://example.com/track/impression</Impression>
+      <Pricing model="cpm" currency="USD">
+        <![CDATA[ 25.00 ]]>
+      </Pricing>
+      <AdTitle>iabtechlab video ad</AdTitle>
+      <Category authority="http://www.iabtechlab.com/categoryauthority">AD CONTENT description category</Category>
+      <Creatives>
+        <Creative id="5480" sequence="1" adId="2447226">
+          <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
+          <Linear>
+            <TrackingEvents>
+              <Tracking event="start" offset="08:34:01">http://example.com/tracking/start</Tracking>
+              <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
+              <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
+              <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
+              <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+            </TrackingEvents>
+            <Duration>00:00:16</Duration>
+            <MediaFiles>
+              <MediaFile id="5241" delivery="progressive" type="video/mp4" bitrate="2000" width="1280" height="720" minBitrate="1500" maxBitrate="2500" scalable="1" maintainAspectRatio="1" codec="0">
+                <![CDATA[https://iabtechlab.com/wp-content/uploads/2016/07/VAST-4.0-Short-Intro.mp4]]>
+              </MediaFile>
+              <MediaFile id="5244" delivery="progressive" type="video/mp4" bitrate="1000" width="854" height="480" minBitrate="700" maxBitrate="1500" scalable="1" maintainAspectRatio="1" codec="0">
+                <![CDATA[http://example.com/mediafile/mid_resolution.mp4]]>
+              </MediaFile>
+              <MediaFile id="5246" delivery="progressive" type="video/mp4" bitrate="600" width="640" height="360" minBitrate="500" maxBitrate="700" scalable="1" maintainAspectRatio="1" codec="0">
+                <![CDATA[http://example.com/mediafile/low_resolution.mp4]]>
+              </MediaFile>
+            </MediaFiles>
+            <VideoClicks>
+              <ClickThrough id="blog">
+                <![CDATA[https://iabtechlab.com]]>
+              </ClickThrough>
+            </VideoClicks>
+          </Linear>
+        </Creative>
+      </Creatives>
+    </InLine>
+  </Ad>
 </VAST>

--- a/VAST 4.0 Samples/Video_Clicks_and_click_tracking-Inline-test.xml
+++ b/VAST 4.0 Samples/Video_Clicks_and_click_tracking-Inline-test.xml
@@ -1,58 +1,55 @@
 <VAST version="4.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.iab.com/VAST">
-    <Ad id="20009" sequence="1" conditionalAd="false">
-        <InLine>
-            <AdSystem version="4.0">iabtechlab</AdSystem>
-            <Error>http://example.com/error</Error>
-            <Extensions>
-                <Extension type="iab-Count">
-                    <total_available>
-                        <![CDATA[ 2 ]]>
-                    </total_available>
-                </Extension>
-            </Extensions>
-            <Impression id="Impression-ID">http://example.com/track/impression</Impression>
-
-            <Pricing model="cpm" currency="USD">
-                <![CDATA[ 25.00 ]]>
-            </Pricing>
-            <AdTitle>iabtechlab video ad</AdTitle>
-
-             <Category authority="http://www.iabtechlab.com/categoryauthority">AD CONTENT description category</Category>
-            <Creatives>
-                <Creative id="5480" sequence="1" adId="2447226">
-                  <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
-                    <Linear>
-                        <TrackingEvents>
-                           <Tracking event="start" offset="09:45:23">http://example.com/tracking/start</Tracking>
-                            <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
-                            <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
-                            <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
-                            <Tracking event="complete">http://example.com/tracking/complete</Tracking>
-                        </TrackingEvents>
-                        <Duration>00:00:16</Duration>
-                        <MediaFiles>
-                          <MediaFile id="5241" delivery="progressive" type="video/mp4" bitrate="2000" width="1280" height="720" minBitrate="1500" maxBitrate="2500" scalable="1" maintainAspectRatio="1" codec="0">
-                              <![CDATA[https://iabtechlab.com/wp-content/uploads/2016/07/VAST-4.0-Short-Intro.mp4]]>
-                          </MediaFile>
-                          <MediaFile id="5244" delivery="progressive" type="video/mp4" bitrate="1000" width="854" height="480" minBitrate="700" maxBitrate="1500" scalable="1" maintainAspectRatio="1" codec="0">
-                              <![CDATA[http://example.com/mediafile/mid_resolution.mp4]]>
-                          </MediaFile>
-                          <MediaFile id="5246" delivery="progressive" type="video/mp4" bitrate="600" width="640" height="360" minBitrate="500" maxBitrate="700" scalable="1" maintainAspectRatio="1" codec="0">
-                              <![CDATA[http://example.com/mediafile/low_resolution.mp4]]>
-                          </MediaFile>
-                        </MediaFiles>
-
-                        <VideoClicks>
-                           <ClickTracking>
-                                <![CDATA[http://myTrackingURL/clickTracking]]>
-                            </ClickTracking>
-                            <ClickThrough id="blog">
-                                <![CDATA[https://iabtechlab.com]]>
-                            </ClickThrough>
-                        </VideoClicks>
-                    </Linear>
-                </Creative>
-            </Creatives>
-        </InLine>
-    </Ad>
+  <Ad id="20009" sequence="1" conditionalAd="false">
+    <InLine>
+      <AdSystem version="4.0">iabtechlab</AdSystem>
+      <Error>http://example.com/error</Error>
+      <Extensions>
+        <Extension type="iab-Count">
+          <total_available>
+            <![CDATA[ 2 ]]>
+          </total_available>
+        </Extension>
+      </Extensions>
+      <Impression id="Impression-ID">http://example.com/track/impression</Impression>
+      <Pricing model="cpm" currency="USD">
+        <![CDATA[ 25.00 ]]>
+      </Pricing>
+      <AdTitle>iabtechlab video ad</AdTitle>
+      <Category authority="http://www.iabtechlab.com/categoryauthority">AD CONTENT description category</Category>
+      <Creatives>
+        <Creative id="5480" sequence="1" adId="2447226">
+          <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
+          <Linear>
+            <TrackingEvents>
+              <Tracking event="start" offset="09:45:23">http://example.com/tracking/start</Tracking>
+              <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
+              <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
+              <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
+              <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+            </TrackingEvents>
+            <Duration>00:00:16</Duration>
+            <MediaFiles>
+              <MediaFile id="5241" delivery="progressive" type="video/mp4" bitrate="2000" width="1280" height="720" minBitrate="1500" maxBitrate="2500" scalable="1" maintainAspectRatio="1" codec="0">
+                <![CDATA[https://iabtechlab.com/wp-content/uploads/2016/07/VAST-4.0-Short-Intro.mp4]]>
+              </MediaFile>
+              <MediaFile id="5244" delivery="progressive" type="video/mp4" bitrate="1000" width="854" height="480" minBitrate="700" maxBitrate="1500" scalable="1" maintainAspectRatio="1" codec="0">
+                <![CDATA[http://example.com/mediafile/mid_resolution.mp4]]>
+              </MediaFile>
+              <MediaFile id="5246" delivery="progressive" type="video/mp4" bitrate="600" width="640" height="360" minBitrate="500" maxBitrate="700" scalable="1" maintainAspectRatio="1" codec="0">
+                <![CDATA[http://example.com/mediafile/low_resolution.mp4]]>
+              </MediaFile>
+            </MediaFiles>
+            <VideoClicks>
+              <ClickTracking>
+                <![CDATA[http://myTrackingURL/clickTracking]]>
+              </ClickTracking>
+              <ClickThrough id="blog">
+                <![CDATA[https://iabtechlab.com]]>
+              </ClickThrough>
+            </VideoClicks>
+          </Linear>
+        </Creative>
+      </Creatives>
+    </InLine>
+  </Ad>
 </VAST>

--- a/VAST 4.0 Samples/Viewable_Impression-test.xml
+++ b/VAST 4.0 Samples/Viewable_Impression-test.xml
@@ -1,24 +1,32 @@
 <VAST version="4.0" xmlns="http://www.iab.com/VAST">
-    <Ad id="20010" sequence="1" conditionalAd="false">
-        <Wrapper followAdditionalWrappers="0" allowMultipleAds="1" fallbackOnNoAd="0">
-            <AdSystem version="4.0">iabtechlab</AdSystem>
-            <Error>http://example.com/error</Error>
-            <Impression id="Impression-ID">http://example.com/track/impression</Impression>
-            <ViewableImpression id="1543">
-                 <Viewable><![CDATA[http://search.iabtechlab.com/error?errcode=102&imprid=s5-ea2f7f298e28c0c98374491aec3dfeb1&ts=1243]]></Viewable>
-                 <NotViewable><![CDATA[http://search.iabtechlab.com/error?errcode=102&imprid=s5-ea2f7f298e28c0c98374491aec3dfeb1&ts=1243]]></NotViewable>
-                 <ViewUndetermined><![CDATA[http://search.iabtechlab.com/error?errcode=102&imprid=s5-ea2f7f298e28c0c98374491aec3dfeb1&ts=1243]]></ViewUndetermined>
-            </ViewableImpression>
-            <Creatives>
-                <Creative id="5480" sequence="1" adId="2447226">
-                    <Linear>
-                        <TrackingEvents>
-                           <Tracking event="start" offset="09:00:10">http://example.com/tracking/start</Tracking>
-                        </TrackingEvents>
-                    </Linear>
-                </Creative>
-            </Creatives>
-            <VASTAdTagURI><![CDATA[https://raw.githubusercontent.com/InteractiveAdvertisingBureau/VAST_Samples/master/VAST%204.0%20Samples/Inline_Companion_Tag-test.xml]]></VASTAdTagURI>
-        </Wrapper>
-    </Ad>
+  <Ad id="20010" sequence="1" conditionalAd="false">
+    <Wrapper followAdditionalWrappers="0" allowMultipleAds="1" fallbackOnNoAd="0">
+      <AdSystem version="4.0">iabtechlab</AdSystem>
+      <Error>http://example.com/error</Error>
+      <Impression id="Impression-ID">http://example.com/track/impression</Impression>
+      <ViewableImpression id="1543">
+        <Viewable>
+          <![CDATA[http://search.iabtechlab.com/error?errcode=102&imprid=s5-ea2f7f298e28c0c98374491aec3dfeb1&ts=1243]]>
+        </Viewable>
+        <NotViewable>
+          <![CDATA[http://search.iabtechlab.com/error?errcode=102&imprid=s5-ea2f7f298e28c0c98374491aec3dfeb1&ts=1243]]>
+        </NotViewable>
+        <ViewUndetermined>
+          <![CDATA[http://search.iabtechlab.com/error?errcode=102&imprid=s5-ea2f7f298e28c0c98374491aec3dfeb1&ts=1243]]>
+        </ViewUndetermined>
+      </ViewableImpression>
+      <Creatives>
+        <Creative id="5480" sequence="1" adId="2447226">
+          <Linear>
+            <TrackingEvents>
+              <Tracking event="start" offset="09:00:10">http://example.com/tracking/start</Tracking>
+            </TrackingEvents>
+          </Linear>
+        </Creative>
+      </Creatives>
+      <VASTAdTagURI>
+        <![CDATA[https://raw.githubusercontent.com/InteractiveAdvertisingBureau/VAST_Samples/master/VAST%204.0%20Samples/Inline_Companion_Tag-test.xml]]>
+      </VASTAdTagURI>
+    </Wrapper>
+  </Ad>
 </VAST>

--- a/VAST 4.0 Samples/Wrapper_Tag-test.xml
+++ b/VAST 4.0 Samples/Wrapper_Tag-test.xml
@@ -1,25 +1,26 @@
 <VAST version="4.0" xmlns="http://www.iab.com/VAST">
-    <Ad id="20011" sequence="1" conditionalAd="false">
-        <Wrapper followAdditionalWrappers="0" allowMultipleAds="1" fallbackOnNoAd="0">
-            <AdSystem version="4.0">iabtechlab</AdSystem>
-            <Error>http://example.com/error</Error>
-            <Impression id="Impression-ID">http://example.com/track/impression</Impression>
-            <Creatives>
-                <Creative id="5480" sequence="1" adId="2447226">
-                  <CompanionAds>
-                      <Companion id="1232" width="100" height="150" assetWidth="250" assetHeight="200" expandedWidth="350" expandedHeight="250"
-  					apiFramework="VPAID" adSlotID="3214" pxratio="1400" >
-                              <StaticResource creativeType="image/png">
-                                  <![CDATA[https://www.iab.com/wp-content/uploads/2014/09/iab-tech-lab-6-644x290.png]]>
-                              </StaticResource>
-                              <CompanionClickThrough>
-                                  <![CDATA[https://iabtechlab.com]]>
-                              </CompanionClickThrough>
-                      </Companion>
-                  </CompanionAds>
-                </Creative>
-            </Creatives>
-            <VASTAdTagURI><![CDATA[https://raw.githubusercontent.com/InteractiveAdvertisingBureau/VAST_Samples/master/VAST%204.0%20Samples/Inline_Companion_Tag-test.xml]]></VASTAdTagURI>
-        </Wrapper>
-    </Ad>
+  <Ad id="20011" sequence="1" conditionalAd="false">
+    <Wrapper followAdditionalWrappers="0" allowMultipleAds="1" fallbackOnNoAd="0">
+      <AdSystem version="4.0">iabtechlab</AdSystem>
+      <Error>http://example.com/error</Error>
+      <Impression id="Impression-ID">http://example.com/track/impression</Impression>
+      <Creatives>
+        <Creative id="5480" sequence="1" adId="2447226">
+          <CompanionAds>
+            <Companion id="1232" width="100" height="150" assetWidth="250" assetHeight="200" expandedWidth="350" expandedHeight="250" apiFramework="VPAID" adSlotID="3214" pxratio="1400">
+              <StaticResource creativeType="image/png">
+                <![CDATA[https://www.iab.com/wp-content/uploads/2014/09/iab-tech-lab-6-644x290.png]]>
+              </StaticResource>
+              <CompanionClickThrough>
+                <![CDATA[https://iabtechlab.com]]>
+              </CompanionClickThrough>
+            </Companion>
+          </CompanionAds>
+        </Creative>
+      </Creatives>
+      <VASTAdTagURI>
+        <![CDATA[https://raw.githubusercontent.com/InteractiveAdvertisingBureau/VAST_Samples/master/VAST%204.0%20Samples/Inline_Companion_Tag-test.xml]]>
+      </VASTAdTagURI>
+    </Wrapper>
+  </Ad>
 </VAST>


### PR DESCRIPTION
In `inline-simple.xml` the `category` element did not contain the required `authority` attribute, according to spec. 

https://www.iab.com/wp-content/uploads/2016/04/VAST4.0_Updated_April_2016.pdf