### PR TITLE
Properly use offset attribute

### DIFF
--- a/VAST 3.0 Samples/Event_Tracking-test.xml
+++ b/VAST 3.0 Samples/Event_Tracking-test.xml
@@ -13,11 +13,12 @@
                     <Linear>
                         <Duration>00:00:16</Duration>
                         <TrackingEvents>
-                           <Tracking event="start" offset="10:05:20">http://example.com/tracking/start</Tracking>
+                            <Tracking event="start">http://example.com/tracking/start</Tracking>
                             <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
                             <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
                             <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
                             <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+                            <Tracking event="progress" offset="00:00:10">http://example.com/tracking/progress-10</Tracking>
                         </TrackingEvents>
                         <VideoClicks>
                             <ClickThrough id="blog">

--- a/VAST 3.0 Samples/Inline_Companion_Tag-test.xml
+++ b/VAST 3.0 Samples/Inline_Companion_Tag-test.xml
@@ -34,11 +34,12 @@
                     <Linear>
                         <Duration>00:00:16</Duration>
                         <TrackingEvents>
-                           <Tracking event="start" offset="09:15:23">http://example.com/tracking/start</Tracking>
+                            <Tracking event="start">http://example.com/tracking/start</Tracking>
                             <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
                             <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
                             <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
                             <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+                            <Tracking event="progress" offset="00:00:10">http://example.com/tracking/progress-10</Tracking>
                         </TrackingEvents>
 
                         <VideoClicks>

--- a/VAST 3.0 Samples/Inline_Linear_Tag-test.xml
+++ b/VAST 3.0 Samples/Inline_Linear_Tag-test.xml
@@ -17,11 +17,12 @@
                     <Linear>
                         <Duration>00:00:16</Duration>
                         <TrackingEvents>
-                           <Tracking event="start" offset="09:15:23">http://example.com/tracking/start</Tracking>
+                            <Tracking event="start">http://example.com/tracking/start</Tracking>
                             <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
                             <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
                             <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
                             <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+                            <Tracking event="progress" offset="00:00:10">http://example.com/tracking/progress-10</Tracking>
                         </TrackingEvents>
 
                          <VideoClicks>

--- a/VAST 3.0 Samples/No_Wrapper_Tag-test.xml
+++ b/VAST 3.0 Samples/No_Wrapper_Tag-test.xml
@@ -15,11 +15,12 @@
                     <Linear>
                         <Duration>00:00:16</Duration>
                         <TrackingEvents>
-                           <Tracking event="start" offset="09:34:50">http://example.com/tracking/start</Tracking>
+                            <Tracking event="start">http://example.com/tracking/start</Tracking>
                             <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
                             <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
                             <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
                             <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+                            <Tracking event="progress" offset="00:00:10">http://example.com/tracking/progress-10</Tracking>
                         </TrackingEvents>
 
                         <VideoClicks>

--- a/VAST 3.0 Samples/Video_Clicks_and_click_tracking-Inline-test.xml
+++ b/VAST 3.0 Samples/Video_Clicks_and_click_tracking-Inline-test.xml
@@ -14,11 +14,12 @@
                         <Duration>00:00:16</Duration>
 
                         <TrackingEvents>
-                           <Tracking event="start" offset="09:45:23">http://example.com/tracking/start</Tracking>
+                            <Tracking event="start">http://example.com/tracking/start</Tracking>
                             <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
                             <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
                             <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
                             <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+                            <Tracking event="progress" offset="00:00:10">http://example.com/tracking/progress-10</Tracking>
                         </TrackingEvents>
 
                         <VideoClicks>

--- a/VAST 4.0 Samples/Ad_Verification-test.xml
+++ b/VAST 4.0 Samples/Ad_Verification-test.xml
@@ -34,11 +34,12 @@
           <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
           <Linear>
             <TrackingEvents>
-              <Tracking event="start" offset="12:22:11">http://example.com/tracking/start</Tracking>
+              <Tracking event="start">http://example.com/tracking/start</Tracking>
               <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
               <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
               <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
               <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+              <Tracking event="progress" offset="00:00:10">http://example.com/tracking/progress-10</Tracking>
             </TrackingEvents>
             <Duration>00:00:16</Duration>
             <MediaFiles>

--- a/VAST 4.0 Samples/Category-test.xml
+++ b/VAST 4.0 Samples/Category-test.xml
@@ -16,11 +16,12 @@
           <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
           <Linear>
             <TrackingEvents>
-              <Tracking event="start" offset="08:34:01">http://example.com/tracking/start</Tracking>
+              <Tracking event="start">http://example.com/tracking/start</Tracking>
               <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
               <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
               <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
               <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+              <Tracking event="progress" offset="00:00:10">http://example.com/tracking/progress-10</Tracking>
             </TrackingEvents>
             <Duration>00:00:16</Duration>
             <MediaFiles>

--- a/VAST 4.0 Samples/Conditional_Ad-test.xml
+++ b/VAST 4.0 Samples/Conditional_Ad-test.xml
@@ -21,11 +21,12 @@
           <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
           <Linear>
             <TrackingEvents>
-              <Tracking event="start" offset="12:20:10">http://example.com/tracking/start</Tracking>
+              <Tracking event="start">http://example.com/tracking/start</Tracking>
               <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
               <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
               <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
               <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+              <Tracking event="progress" offset="00:00:10">http://example.com/tracking/progress-10</Tracking>
             </TrackingEvents>
             <Duration>00:00:16</Duration>
             <MediaFiles>

--- a/VAST 4.0 Samples/Event_Tracking-test.xml
+++ b/VAST 4.0 Samples/Event_Tracking-test.xml
@@ -20,11 +20,12 @@
           <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
           <Linear>
             <TrackingEvents>
-              <Tracking event="start" offset="10:05:20">http://example.com/tracking/start</Tracking>
+              <Tracking event="start">http://example.com/tracking/start</Tracking>
               <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
               <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
               <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
               <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+              <Tracking event="progress" offset="00:00:10">http://example.com/tracking/progress-10</Tracking>
             </TrackingEvents>
             <Duration>00:00:16</Duration>
             <MediaFiles>

--- a/VAST 4.0 Samples/Inline_Companion_Tag-test.xml
+++ b/VAST 4.0 Samples/Inline_Companion_Tag-test.xml
@@ -34,11 +34,12 @@
         <Creative id="5480" sequence="1" adId="2447226">
           <Linear>
             <TrackingEvents>
-              <Tracking event="start" offset="09:15:23">http://example.com/tracking/start</Tracking>
+              <Tracking event="start">http://example.com/tracking/start</Tracking>
               <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
               <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
               <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
               <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+              <Tracking event="progress" offset="00:00:10">http://example.com/tracking/progress-10</Tracking>
             </TrackingEvents>
             <Duration>00:00:16</Duration>
             <MediaFiles>

--- a/VAST 4.0 Samples/Inline_Linear_Tag-test.xml
+++ b/VAST 4.0 Samples/Inline_Linear_Tag-test.xml
@@ -20,11 +20,12 @@
           <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
           <Linear>
             <TrackingEvents>
-              <Tracking event="start" offset="09:15:23">http://example.com/tracking/start</Tracking>
+              <Tracking event="start">http://example.com/tracking/start</Tracking>
               <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
               <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
               <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
               <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+              <Tracking event="progress" offset="00:00:10">http://example.com/tracking/progress-10</Tracking>
             </TrackingEvents>
             <Duration>00:00:16</Duration>
             <MediaFiles>

--- a/VAST 4.0 Samples/Inline_Simple.xml
+++ b/VAST 4.0 Samples/Inline_Simple.xml
@@ -16,11 +16,12 @@
           <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
           <Linear>
             <TrackingEvents>
-              <Tracking event="start" offset="09:15:23">http://example.com/tracking/start</Tracking>
+              <Tracking event="start">http://example.com/tracking/start</Tracking>
               <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
               <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
               <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
               <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+              <Tracking event="progress" offset="00:00:10">http://example.com/tracking/progress-10</Tracking>
             </TrackingEvents>
             <Duration>00:00:16</Duration>
             <MediaFiles>

--- a/VAST 4.0 Samples/No_Wrapper_Tag-test.xml
+++ b/VAST 4.0 Samples/No_Wrapper_Tag-test.xml
@@ -20,11 +20,12 @@
           <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
           <Linear>
             <TrackingEvents>
-              <Tracking event="start" offset="09:34:50">http://example.com/tracking/start</Tracking>
+              <Tracking event="start">http://example.com/tracking/start</Tracking>
               <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
               <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
               <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
               <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+              <Tracking event="progress" offset="00:00:10">http://example.com/tracking/progress-10</Tracking>
             </TrackingEvents>
             <Duration>00:00:16</Duration>
             <MediaFiles>

--- a/VAST 4.0 Samples/Ready_to_serve_Media_Files_check-test.xml
+++ b/VAST 4.0 Samples/Ready_to_serve_Media_Files_check-test.xml
@@ -20,11 +20,12 @@
           <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
           <Linear>
             <TrackingEvents>
-              <Tracking event="start" offset="01:28:23">http://example.com/tracking/start</Tracking>
+              <Tracking event="start">http://example.com/tracking/start</Tracking>
               <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
               <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
               <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
               <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+              <Tracking event="progress" offset="00:00:10">http://example.com/tracking/progress-10</Tracking>
             </TrackingEvents>
             <Duration>00:00:16</Duration>
             <MediaFiles>

--- a/VAST 4.0 Samples/SSAI_stitching _VPAID_separation-test.xml
+++ b/VAST 4.0 Samples/SSAI_stitching _VPAID_separation-test.xml
@@ -20,11 +20,12 @@
           <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
           <Linear>
             <TrackingEvents>
-              <Tracking event="start" offset="10:32:23">http://example.com/tracking/start</Tracking>
+              <Tracking event="start">http://example.com/tracking/start</Tracking>
               <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
               <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
               <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
               <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+              <Tracking event="progress" offset="00:00:10">http://example.com/tracking/progress-10</Tracking>
             </TrackingEvents>
             <Duration>00:00:16</Duration>
             <MediaFiles>

--- a/VAST 4.0 Samples/SSAI_stitching_mezzanine_file_support-test.xml
+++ b/VAST 4.0 Samples/SSAI_stitching_mezzanine_file_support-test.xml
@@ -13,11 +13,12 @@
           <UniversalAdId idRegistry="Ad-ID" idValue="8465">1234</UniversalAdId>
           <Linear>
             <TrackingEvents>
-              <Tracking event="start" offset="01:34:00">http://example.com/tracking/start</Tracking>
+              <Tracking event="start">http://example.com/tracking/start</Tracking>
               <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
               <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
               <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
               <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+              <Tracking event="progress" offset="00:00:10">http://example.com/tracking/progress-10</Tracking>
             </TrackingEvents>
             <Duration>00:00:16</Duration>
             <MediaFiles>

--- a/VAST 4.0 Samples/Universal_Ad_ID-test.xml
+++ b/VAST 4.0 Samples/Universal_Ad_ID-test.xml
@@ -21,11 +21,12 @@
           <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
           <Linear>
             <TrackingEvents>
-              <Tracking event="start" offset="08:34:01">http://example.com/tracking/start</Tracking>
+              <Tracking event="start">http://example.com/tracking/start</Tracking>
               <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
               <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
               <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
               <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+              <Tracking event="progress" offset="00:00:10">http://example.com/tracking/progress-10</Tracking>
             </TrackingEvents>
             <Duration>00:00:16</Duration>
             <MediaFiles>

--- a/VAST 4.0 Samples/Video_Clicks_and_click_tracking-Inline-test.xml
+++ b/VAST 4.0 Samples/Video_Clicks_and_click_tracking-Inline-test.xml
@@ -21,11 +21,12 @@
           <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
           <Linear>
             <TrackingEvents>
-              <Tracking event="start" offset="09:45:23">http://example.com/tracking/start</Tracking>
+              <Tracking event="start">http://example.com/tracking/start</Tracking>
               <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
               <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
               <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
               <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+              <Tracking event="progress" offset="00:00:10">http://example.com/tracking/progress-10</Tracking>
             </TrackingEvents>
             <Duration>00:00:16</Duration>
             <MediaFiles>

--- a/VAST 4.0 Samples/Viewable_Impression-test.xml
+++ b/VAST 4.0 Samples/Viewable_Impression-test.xml
@@ -19,7 +19,8 @@
         <Creative id="5480" sequence="1" adId="2447226">
           <Linear>
             <TrackingEvents>
-              <Tracking event="start" offset="09:00:10">http://example.com/tracking/start</Tracking>
+              <Tracking event="start">http://example.com/tracking/start</Tracking>
+              <Tracking event="progress" offset="00:00:10">http://example.com/tracking/progress-10</Tracking>
             </TrackingEvents>
           </Linear>
         </Creative>

--- a/VAST 4.1 Samples/Ad_Verification-test.xml
+++ b/VAST 4.1 Samples/Ad_Verification-test.xml
@@ -35,11 +35,12 @@
           <UniversalAdId idRegistry="Ad-ID" >8465</UniversalAdId>
           <Linear>
             <TrackingEvents>
-              <Tracking event="start" offset="12:22:11">http://example.com/tracking/start</Tracking>
+              <Tracking event="start">http://example.com/tracking/start</Tracking>
               <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
               <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
               <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
               <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+              <Tracking event="progress" offset="00:00:10">http://example.com/tracking/progress-10</Tracking>
             </TrackingEvents>
             <Duration>00:00:16</Duration>
             <MediaFiles>

--- a/VAST 4.1 Samples/Audio_DAAST_Sample.xml
+++ b/VAST 4.1 Samples/Audio_DAAST_Sample.xml
@@ -21,11 +21,12 @@
           <UniversalAdId idRegistry="Ad-ID" >8465</UniversalAdId>
           <Linear>
             <TrackingEvents>
-              <Tracking event="start" offset="01:28:23">http://example.com/tracking/start</Tracking>
+              <Tracking event="start">http://example.com/tracking/start</Tracking>
               <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
               <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
               <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
               <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+              <Tracking event="progress" offset="00:00:10">http://example.com/tracking/progress-10</Tracking>
             </TrackingEvents>
             <Duration>00:00:16</Duration>
             <MediaFiles>

--- a/VAST 4.1 Samples/Category-test.xml
+++ b/VAST 4.1 Samples/Category-test.xml
@@ -17,11 +17,12 @@
           <UniversalAdId idRegistry="Ad-ID" >8465</UniversalAdId>
           <Linear>
             <TrackingEvents>
-              <Tracking event="start" offset="08:34:01">http://example.com/tracking/start</Tracking>
+              <Tracking event="start">http://example.com/tracking/start</Tracking>
               <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
               <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
               <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
               <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+              <Tracking event="progress" offset="00:00:10">http://example.com/tracking/progress-10</Tracking>
             </TrackingEvents>
             <Duration>00:00:16</Duration>
             <MediaFiles>

--- a/VAST 4.1 Samples/Closed_Caption_Test.xml
+++ b/VAST 4.1 Samples/Closed_Caption_Test.xml
@@ -21,11 +21,12 @@
           <UniversalAdId idRegistry="Ad-ID" >8465</UniversalAdId>
           <Linear>
             <TrackingEvents>
-              <Tracking event="start" offset="09:15:23">http://example.com/tracking/start</Tracking>
+              <Tracking event="start">http://example.com/tracking/start</Tracking>
               <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
               <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
               <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
               <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+              <Tracking event="progress" offset="00:00:10">http://example.com/tracking/progress-10</Tracking>
             </TrackingEvents>
             <Duration>00:00:16</Duration>
             <MediaFiles>

--- a/VAST 4.1 Samples/Conditional_Ad-test.xml
+++ b/VAST 4.1 Samples/Conditional_Ad-test.xml
@@ -22,11 +22,12 @@
           <UniversalAdId idRegistry="Ad-ID" >8465</UniversalAdId>
           <Linear>
             <TrackingEvents>
-              <Tracking event="start" offset="12:20:10">http://example.com/tracking/start</Tracking>
+              <Tracking event="start">http://example.com/tracking/start</Tracking>
               <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
               <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
               <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
               <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+              <Tracking event="progress" offset="00:00:10">http://example.com/tracking/progress-10</Tracking>
             </TrackingEvents>
             <Duration>00:00:16</Duration>
             <MediaFiles>

--- a/VAST 4.1 Samples/Event_Tracking-test.xml
+++ b/VAST 4.1 Samples/Event_Tracking-test.xml
@@ -21,11 +21,12 @@
           <UniversalAdId idRegistry="Ad-ID" >8465</UniversalAdId>
           <Linear>
             <TrackingEvents>
-              <Tracking event="start" offset="10:05:20">http://example.com/tracking/start</Tracking>
+              <Tracking event="start">http://example.com/tracking/start</Tracking>
               <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
               <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
               <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
               <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+              <Tracking event="progress" offset="00:00:10">http://example.com/tracking/progress-10</Tracking>
             </TrackingEvents>
             <Duration>00:00:16</Duration>
             <MediaFiles>

--- a/VAST 4.1 Samples/Inline_Companion_Tag-test.xml
+++ b/VAST 4.1 Samples/Inline_Companion_Tag-test.xml
@@ -36,11 +36,12 @@
           <UniversalAdId idRegistry="Ad-ID" >8466</UniversalAdId>
           <Linear>
             <TrackingEvents>
-              <Tracking event="start" offset="09:15:23">http://example.com/tracking/start</Tracking>
+              <Tracking event="start">http://example.com/tracking/start</Tracking>
               <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
               <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
               <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
               <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+              <Tracking event="progress" offset="00:00:10">http://example.com/tracking/progress-10</Tracking>
             </TrackingEvents>
             <Duration>00:00:16</Duration>
             <MediaFiles>

--- a/VAST 4.1 Samples/Inline_Linear_Tag-test.xml
+++ b/VAST 4.1 Samples/Inline_Linear_Tag-test.xml
@@ -21,11 +21,12 @@
           <UniversalAdId idRegistry="Ad-ID" >8465</UniversalAdId>
           <Linear>
             <TrackingEvents>
-              <Tracking event="start" offset="09:15:23">http://example.com/tracking/start</Tracking>
+              <Tracking event="start">http://example.com/tracking/start</Tracking>
               <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
               <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
               <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
               <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+              <Tracking event="progress" offset="00:00:10">http://example.com/tracking/progress-10</Tracking>
             </TrackingEvents>
             <Duration>00:00:16</Duration>
             <MediaFiles>

--- a/VAST 4.1 Samples/Inline_Simple.xml
+++ b/VAST 4.1 Samples/Inline_Simple.xml
@@ -17,11 +17,12 @@
           <UniversalAdId idRegistry="Ad-ID">8465</UniversalAdId>
           <Linear>
             <TrackingEvents>
-              <Tracking event="start" offset="09:15:23">http://example.com/tracking/start</Tracking>
+              <Tracking event="start">http://example.com/tracking/start</Tracking>
               <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
               <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
               <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
               <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+              <Tracking event="progress" offset="00:00:10">http://example.com/tracking/progress-10</Tracking>
             </TrackingEvents>
             <Duration>00:00:16</Duration>
             <MediaFiles>

--- a/VAST 4.1 Samples/No_Wrapper_Tag-test.xml
+++ b/VAST 4.1 Samples/No_Wrapper_Tag-test.xml
@@ -21,11 +21,12 @@
           <UniversalAdId idRegistry="Ad-ID" >8465</UniversalAdId>
           <Linear>
             <TrackingEvents>
-              <Tracking event="start" offset="09:34:50">http://example.com/tracking/start</Tracking>
+              <Tracking event="start">http://example.com/tracking/start</Tracking>
               <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
               <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
               <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
               <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+              <Tracking event="progress" offset="00:00:10">http://example.com/tracking/progress-10</Tracking>
             </TrackingEvents>
             <Duration>00:00:16</Duration>
             <MediaFiles>

--- a/VAST 4.1 Samples/Ready_to_serve_Media_Files_check-test.xml
+++ b/VAST 4.1 Samples/Ready_to_serve_Media_Files_check-test.xml
@@ -21,11 +21,12 @@
           <UniversalAdId idRegistry="Ad-ID" >8465</UniversalAdId>
           <Linear>
             <TrackingEvents>
-              <Tracking event="start" offset="01:28:23">http://example.com/tracking/start</Tracking>
+              <Tracking event="start">http://example.com/tracking/start</Tracking>
               <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
               <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
               <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
               <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+              <Tracking event="progress" offset="00:00:10">http://example.com/tracking/progress-10</Tracking>
             </TrackingEvents>
             <Duration>00:00:16</Duration>
             <MediaFiles>

--- a/VAST 4.1 Samples/SSAI_stitching _VPAID_separation-test.xml
+++ b/VAST 4.1 Samples/SSAI_stitching _VPAID_separation-test.xml
@@ -21,11 +21,12 @@
           <UniversalAdId idRegistry="Ad-ID" >8465</UniversalAdId>
           <Linear>
             <TrackingEvents>
-              <Tracking event="start" offset="10:32:23">http://example.com/tracking/start</Tracking>
+              <Tracking event="start">http://example.com/tracking/start</Tracking>
               <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
               <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
               <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
               <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+              <Tracking event="progress" offset="00:00:10">http://example.com/tracking/progress-10</Tracking>
             </TrackingEvents>
             <Duration>00:00:16</Duration>
             <MediaFiles>

--- a/VAST 4.1 Samples/SSAI_stitching_mezzanine_file_support-test.xml
+++ b/VAST 4.1 Samples/SSAI_stitching_mezzanine_file_support-test.xml
@@ -14,11 +14,12 @@
           <UniversalAdId idRegistry="Ad-ID" >1234</UniversalAdId>
           <Linear>
             <TrackingEvents>
-              <Tracking event="start" offset="01:34:00">http://example.com/tracking/start</Tracking>
+              <Tracking event="start">http://example.com/tracking/start</Tracking>
               <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
               <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
               <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
               <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+              <Tracking event="progress" offset="00:00:10">http://example.com/tracking/progress-10</Tracking>
             </TrackingEvents>
             <Duration>00:00:16</Duration>
             <MediaFiles>

--- a/VAST 4.1 Samples/Universal_Ad_ID-test.xml
+++ b/VAST 4.1 Samples/Universal_Ad_ID-test.xml
@@ -22,11 +22,12 @@
           <UniversalAdId idRegistry="Ad-ID" >8465</UniversalAdId>
           <Linear>
             <TrackingEvents>
-              <Tracking event="start" offset="08:34:01">http://example.com/tracking/start</Tracking>
+              <Tracking event="start">http://example.com/tracking/start</Tracking>
               <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
               <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
               <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
               <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+              <Tracking event="progress" offset="00:00:10">http://example.com/tracking/progress-10</Tracking>
             </TrackingEvents>
             <Duration>00:00:16</Duration>
             <MediaFiles>

--- a/VAST 4.1 Samples/Video_Clicks_and_click_tracking-Inline-test.xml
+++ b/VAST 4.1 Samples/Video_Clicks_and_click_tracking-Inline-test.xml
@@ -22,11 +22,12 @@
           <UniversalAdId idRegistry="Ad-ID">8465</UniversalAdId>
           <Linear>
             <TrackingEvents>
-              <Tracking event="start" offset="09:45:23">http://example.com/tracking/start</Tracking>
+              <Tracking event="start">http://example.com/tracking/start</Tracking>
               <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
               <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
               <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
               <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+              <Tracking event="progress" offset="00:00:10">http://example.com/tracking/progress-10</Tracking>
             </TrackingEvents>
             <Duration>00:00:16</Duration>
             <MediaFiles>

--- a/VAST 4.1 Samples/Viewable_Impression-test.xml
+++ b/VAST 4.1 Samples/Viewable_Impression-test.xml
@@ -19,7 +19,8 @@
         <Creative id="5480" sequence="1" adId="2447226">
           <Linear>
             <TrackingEvents>
-              <Tracking event="start" offset="09:00:10">http://example.com/tracking/start</Tracking>
+              <Tracking event="start">http://example.com/tracking/start</Tracking>
+              <Tracking event="progress" offset="00:00:10">http://example.com/tracking/progress-10</Tracking>
             </TrackingEvents>
           </Linear>
         </Creative>


### PR DESCRIPTION
The samples for all VAST versions use the `offset` attribute with the `start` event, but I don't see how that's valid.

The various specs all say that `offset` defines the time offset at which a `progress` tracker fires, so that people can declare their own timed events. A classic example would be `offset="00:00:03"` to track three seconds of play time.

The current examples are valid per the XSDs. However, I don't think XML Schema even allows you to do complex statements like _"only allow the `offset` attribute to be present if the `event` attribute's value is `progress`"_. That's probably why this inconsistency never got flagged.

Additionally, the example _value_ of the `offset` attribute is always higher than the ad's duration, which doesn't make sense either.

So this PR fixes all those things: it removes the `offset` from the `start` event, introduces a `progress` event with an `offset`, and sets the value of `offset` to a timestamp below the ad's duration.