### PR TITLE
Fix duration of VAST 2 inline regular sample

### DIFF
--- a/VAST 1-2.0 Samples/Inline_LinearRegular_VAST2.0.xml
+++ b/VAST 1-2.0 Samples/Inline_LinearRegular_VAST2.0.xml
@@ -11,7 +11,7 @@
 		<Creatives>
 			<Creative>
 				<Linear>
-					<Duration>00:00:30</Duration>
+					<Duration>00:00:15</Duration>
 					<TrackingEvents></TrackingEvents>
 					<VideoClicks>
 					<ClickThrough id="scanscout">


### PR DESCRIPTION
The VAST reports that https://iab-publicfiles.s3.amazonaws.com/vast/VAST-4.0-Short-Intro.mp4 is 30 seconds long but it's actually 15 seconds.