### PR TITLE
Update Category-test.xml

### DIFF
--- a/VAST 4.1 Samples/Category-test.xml
+++ b/VAST 4.1 Samples/Category-test.xml
@@ -1,7 +1,7 @@
 <VAST version="4.1" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.iab.com/VAST">
   <Ad id="20008" sequence="1" conditionalAd="false">
     <InLine>
-      <AdSystem version="4.0">iabtechlab</AdSystem>
+      <AdSystem version="4.1">iabtechlab</AdSystem>
       <Error><![CDATA[https://example.com/error]]></Error>
       <Impression id="Impression-ID"><![CDATA[https://example.com/track/impression]]></Impression>
       <Pricing model="cpm" currency="USD">


### PR DESCRIPTION
Change AdSystem version to 4.1 to match the rest of the VAST 4.1 samples, and its' own 'VAST version' tag.